### PR TITLE
A few fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,11 @@ endif()
 # Compile GLFW
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw" "ext_build/glfw")
 
+# Python support: add NANOGUI_PYTHON flag to all targets
+if (NANOGUI_BUILD_PYTHON)
+  add_definitions ("-DNANOGUI_PYTHON")
+endif()
+
 # Shared library mode: add NANOGUI_SHARED flag to all targets
 if (NANOGUI_BUILD_SHARED)
   add_definitions ("-DNANOGUI_SHARED")

--- a/include/nanogui/compat.h
+++ b/include/nanogui/compat.h
@@ -1,0 +1,20 @@
+/*
+    nanogui/compat.h -- Compatibility layer
+
+    NanoGUI was developed by Wenzel Jakob <wenzel@inf.ethz.ch>.
+    The widget drawing code is based on the NanoVG demo application
+    by Mikko Mononen.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#pragma once
+
+#include <stdio.h>
+
+#ifdef _MSC_VER
+#define NANOGUI_SNPRINTF _snprintf
+#else
+#define NANOGUI_SNPRINTF snprintf
+#endif

--- a/include/nanogui/layout.h
+++ b/include/nanogui/layout.h
@@ -241,7 +241,12 @@ public:
 
         operator std::string() const {
             char buf[50];
-            snprintf(buf, 50, "Format[pos=(%i, %i), size=(%i, %i), align=(%i, %i)]",
+#ifdef _MSC_VER
+            _snprintf
+#else
+            snprintf
+#endif
+            (buf, 50, "Format[pos=(%i, %i), size=(%i, %i), align=(%i, %i)]",
                 pos[0], pos[1], size[0], size[1], (int) align[0], (int) align[1]);
             return buf;
         }

--- a/include/nanogui/layout.h
+++ b/include/nanogui/layout.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include <nanogui/compat.h>
 #include <nanogui/object.h>
 #include <unordered_map>
 
@@ -241,12 +242,7 @@ public:
 
         operator std::string() const {
             char buf[50];
-#ifdef _MSC_VER
-            _snprintf
-#else
-            snprintf
-#endif
-            (buf, 50, "Format[pos=(%i, %i), size=(%i, %i), align=(%i, %i)]",
+            NANOGUI_SNPRINTF(buf, 50, "Format[pos=(%i, %i), size=(%i, %i), align=(%i, %i)]",
                 pos[0], pos[1], size[0], size[1], (int) align[0], (int) align[1]);
             return buf;
         }

--- a/include/nanogui/opengl.h
+++ b/include/nanogui/opengl.h
@@ -16,7 +16,7 @@
 
 #if defined(__APPLE__)
     #define GLFW_INCLUDE_GLCOREARB
-#elif defined(WIN32)
+#elif defined(_WIN32)
     #define GLEW_STATIC
     #include <GL/glew.h>
 #else

--- a/include/nanogui/opengl.h
+++ b/include/nanogui/opengl.h
@@ -17,7 +17,9 @@
 #if defined(__APPLE__)
     #define GLFW_INCLUDE_GLCOREARB
 #elif defined(_WIN32)
+    #ifndef GLEW_STATIC
     #define GLEW_STATIC
+    #endif
     #include <GL/glew.h>
 #else
     #define GL_GLEXT_PROTOTYPES

--- a/include/nanogui/textbox.h
+++ b/include/nanogui/textbox.h
@@ -148,7 +148,12 @@ public:
 
     void setValue(Scalar value) {
         char buffer[30];
-        snprintf(buffer, 30, sizeof(Scalar) == sizeof(float) ? "%.4g" : "%.7g", value);
+#ifdef _MSC_VER
+        _snprintf
+#else
+        snprintf
+#endif
+        (buffer, 30, sizeof(Scalar) == sizeof(float) ? "%.4g" : "%.7g", value);
         TextBox::setValue(buffer);
     }
 

--- a/include/nanogui/textbox.h
+++ b/include/nanogui/textbox.h
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include <nanogui/compat.h>
 #include <nanogui/widget.h>
 #include <sstream>
 
@@ -148,12 +149,7 @@ public:
 
     void setValue(Scalar value) {
         char buffer[30];
-#ifdef _MSC_VER
-        _snprintf
-#else
-        snprintf
-#endif
-        (buffer, 30, sizeof(Scalar) == sizeof(float) ? "%.4g" : "%.7g", value);
+        NANOGUI_SNPRINTF(buffer, 30, sizeof(Scalar) == sizeof(float) ? "%.4g" : "%.7g", value);
         TextBox::setValue(buffer);
     }
 

--- a/python/python.cpp
+++ b/python/python.cpp
@@ -1,3 +1,5 @@
+#ifdef NANOGUI_PYTHON
+
 #include <nanogui/nanogui.h>
 #include <nanogui/opengl.h>
 #include "python.h"
@@ -781,3 +783,5 @@ PYBIND11_PLUGIN(nanogui) {
 
     return m.ptr();
 }
+
+#endif

--- a/resources/bin2c.c
+++ b/resources/bin2c.c
@@ -35,7 +35,7 @@ int main(int argc, char **argv) {
 	fprintf(f_h, "#include <stdint.h>\n\n");
 
 	for (i=3; i<(unsigned int) argc; ++i) {
-		char *name = strdup(strrchr(argv[i], '/') + 1);
+		char *name = strdup(strrchr(argv[i], '/') ? strrchr(argv[i], '/')+1 : argv[i] );
 		for (j=0; j<strlen(name); ++j) {
 			if (name[j] == '.' || name[j] == '-')
 				name[j] = '_';


### PR DESCRIPTION
- Fix _WIN32 directive 
- Do not redefine GLEW_STATIC if already present (ie, when embedding NanoGUI in an external project)
- Fix MSVC snprintf (defaults to _snprintf)
- Fix crash if no slashes are present at given filenames (bin2c.c)
