### PR TITLE
made Screen independent of glfw by splitting into ScreenCore & Screen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,6 @@ cmake_minimum_required (VERSION 2.8.3)
 
 project("NanoGUI")
 
-if(NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw/src")
-  message(FATAL_ERROR "The NanoGUI dependency repositories (GLFW, etc.) are missing! "
-    "You probably did not clone the project with --recursive. It is possible to recover "
-    "by calling \"git submodule update --init --recursive\"")
-endif()
-
 option(NANOGUI_BUILD_EXAMPLE "Build NanoGUI example application?" ON)
 option(NANOGUI_BUILD_SHARED  "Build NanoGUI as a shared library?" ON)
 option(NANOGUI_BUILD_PYTHON  "Build a Python plugin for NanoGUI?" ON)
@@ -35,19 +29,29 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 endif()
 string(TOUPPER "${CMAKE_BUILD_TYPE}" U_CMAKE_BUILD_TYPE)
 
-set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL " " FORCE)
-set(GLFW_BUILD_TESTS OFF CACHE BOOL " " FORCE)
-set(GLFW_BUILD_DOCS OFF CACHE BOOL " " FORCE)
-set(GLFW_BUILD_INSTALL OFF CACHE BOOL " " FORCE)
-set(BUILD_SHARED_LIBS ${NANOGUI_BUILD_SHARED} CACHE BOOL " " FORCE)
-
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  # Quench annoying deprecation warnings when compiling GLFW on OSX
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
+# GLFW
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules ${CMAKE_MODULE_PATH})
+find_package(GLFW QUIET)
+if(NOT GLFW_FOUND AND NOT IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw/src")
+  message(FATAL_ERROR "The NanoGUI dependency repositories (GLFW, etc.) are missing! "
+    "You probably did not clone the project with --recursive. It is possible to recover "
+    "by calling \"git submodule update --init --recursive\"")
 endif()
-
-# Compile GLFW
-add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw" "ext_build/glfw")
+if(GLFW_FOUND)
+  list(APPEND NANOGUI_EXTRA_LIBS ${GLFW_LIBRARIES})
+else()
+  set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL " " FORCE)
+  set(GLFW_BUILD_TESTS OFF CACHE BOOL " " FORCE)
+  set(GLFW_BUILD_DOCS OFF CACHE BOOL " " FORCE)
+  set(GLFW_BUILD_INSTALL OFF CACHE BOOL " " FORCE)
+  set(BUILD_SHARED_LIBS ${NANOGUI_BUILD_SHARED} CACHE BOOL " " FORCE)
+  if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    # Quench annoying deprecation warnings when compiling GLFW on OSX
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-deprecated-declarations")
+  endif()
+  # Compile GLFW
+  add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw" "ext_build/glfw")
+endif()
 
 # Shared library mode: add NANOGUI_SHARED flag to all targets
 if (NANOGUI_BUILD_SHARED)
@@ -106,7 +110,12 @@ elseif("${CMAKE_SYSTEM}" MATCHES "Linux")
   list(APPEND NANOGUI_EXTRA_LIBS GL Xxf86vm Xrandr Xinerama Xcursor Xi X11 pthread dl rt)
 endif()
 
-include_directories(ext/eigen ext/glfw/include ext/nanovg/src include ${CMAKE_CURRENT_BINARY_DIR})
+if(GLFW_FOUND)
+  set(glfw_include_dirs ${GLFW_INCLUDE_DIRS})
+else()
+  set(glfw_include_dirs ext/glfw/include)
+endif()
+set(nanogui_include_dirs ${glfw_include_dirs} ext/eigen ext/nanovg/src include ${CMAKE_CURRENT_BINARY_DIR})
 
 # Run simple C converter to put font files into the data segment
 add_executable(bin2c resources/bin2c.c)
@@ -134,47 +143,59 @@ else()
   set(NANOGUI_LIBRARY_TYPE "STATIC")
 endif()
 
-# Compile main NanoGUI library
-add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
-  # Merge GLFW into the NanoGUI library
-  $<TARGET_OBJECTS:glfw_objects>
-  # Merge NanoVG into the NanoGUI library
-  ext/nanovg/src/nanovg.c
-  # Merge GLEW into the NanoGUI library (only if needed)
-  ${LIBNANOGUI_EXTRA_SOURCE}
-  # Fonts etc.
-  resources.cpp
-  include/nanogui/glutil.h src/glutil.cpp
-  include/nanogui/common.h src/common.cpp
-  include/nanogui/widget.h src/widget.cpp
-  include/nanogui/theme.h src/theme.cpp
-  include/nanogui/layout.h src/layout.cpp
-  include/nanogui/screen.h src/screen.cpp
-  include/nanogui/label.h src/label.cpp
-  include/nanogui/window.h src/window.cpp
-  include/nanogui/popup.h src/popup.cpp
-  include/nanogui/checkbox.h src/checkbox.cpp
-  include/nanogui/button.h src/button.cpp
-  include/nanogui/popupbutton.h src/popupbutton.cpp
-  include/nanogui/combobox.h src/combobox.cpp
-  include/nanogui/progressbar.h src/progressbar.cpp
-  include/nanogui/slider.h src/slider.cpp
-  include/nanogui/messagedialog.h src/messagedialog.cpp
-  include/nanogui/textbox.h src/textbox.cpp
-  include/nanogui/imagepanel.h src/imagepanel.cpp
-  include/nanogui/imageview.h src/imageview.cpp
-  include/nanogui/vscrollpanel.h src/vscrollpanel.cpp
-  include/nanogui/colorwheel.h src/colorwheel.cpp
-  include/nanogui/colorpicker.h src/colorpicker.cpp
-  include/nanogui/graph.h src/graph.cpp
-  include/nanogui/formhelper.h
-  include/nanogui/toolbutton.h
-  include/nanogui/opengl.h
-  include/nanogui/nanogui.h
+set(glfw_obj "")
+if(NOT GLFW_FOUND)
+  set(glfw_obj $<TARGET_OBJECTS:glfw_objects>)
+endif()
+set(nanogui_src
+    # Merge GLFW into the NanoGUI library
+    ${glfw_obj}
+    # Merge NanoVG into the NanoGUI library
+    ext/nanovg/src/nanovg.c
+    # Merge GLEW into the NanoGUI library (only if needed)
+    ${LIBNANOGUI_EXTRA_SOURCE}
+    # Fonts etc.
+    resources.cpp
+    include/nanogui/glutil.h src/glutil.cpp
+    include/nanogui/common.h src/common.cpp
+    include/nanogui/widget.h src/widget.cpp
+    include/nanogui/theme.h src/theme.cpp
+    include/nanogui/layout.h src/layout.cpp
+    include/nanogui/screen_core.h src/screen_core.cpp
+    include/nanogui/screen.h src/screen.cpp
+    include/nanogui/label.h src/label.cpp
+    include/nanogui/window.h src/window.cpp
+    include/nanogui/popup.h src/popup.cpp
+    include/nanogui/checkbox.h src/checkbox.cpp
+    include/nanogui/button.h src/button.cpp
+    include/nanogui/popupbutton.h src/popupbutton.cpp
+    include/nanogui/combobox.h src/combobox.cpp
+    include/nanogui/progressbar.h src/progressbar.cpp
+    include/nanogui/slider.h src/slider.cpp
+    include/nanogui/messagedialog.h src/messagedialog.cpp
+    include/nanogui/textbox.h src/textbox.cpp
+    include/nanogui/imagepanel.h src/imagepanel.cpp
+    include/nanogui/imageview.h src/imageview.cpp
+    include/nanogui/vscrollpanel.h src/vscrollpanel.cpp
+    include/nanogui/colorwheel.h src/colorwheel.cpp
+    include/nanogui/colorpicker.h src/colorpicker.cpp
+    include/nanogui/graph.h src/graph.cpp
+    include/nanogui/formhelper.h
+    include/nanogui/toolbutton.h
+    include/nanogui/opengl.h
+    include/nanogui/nanogui.h
 )
+
+# Compile main NanoGUI library
+add_library(nanogui ${NANOGUI_LIBRARY_TYPE} ${nanogui_src})
+
+target_include_directories(nanogui PUBLIC ${nanogui_include_dirs})
 
 # Compile/link flags for NanoGUI
 set_property(TARGET nanogui APPEND PROPERTY COMPILE_DEFINITIONS "NANOGUI_BUILD ")
+set_target_properties(nanogui PROPERTIES
+    CXX_STANDARD 11
+    CXX_STANDARD_REQUIRED ON)
 
 if (NANOGUI_BUILD_SHARED)
   target_link_libraries(nanogui ${NANOGUI_EXTRA_LIBS})
@@ -191,7 +212,7 @@ if (NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG AND NANOGUI_BUILD_SHARED)
   endif()
 endif()
 
-if (NANOGUI_BUILD_SHARED)
+if(NANOGUI_BUILD_SHARED AND NANOGUI_BUILD_WITH_GLFW)
   # When GLFW is merged into the NanoGUI library, this flag must be specified
   set_property(TARGET nanogui APPEND PROPERTY COMPILE_DEFINITIONS "_GLFW_BUILD_DLL ")
 endif()
@@ -234,7 +255,9 @@ endif()
 if (NANOGUI_BUILD_PYTHON)
   # Need PIC code in libnanogui even when compiled as a static library
   set_target_properties(nanogui PROPERTIES POSITION_INDEPENDENT_CODE ON)
-  set_target_properties(glfw_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  if (NOT GLFW_FOUND)
+    set_target_properties(glfw_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
+  endif()
 
   # Detect Python
   set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6)
@@ -306,8 +329,9 @@ add_custom_target(mkdoc COMMAND
 
 get_directory_property(NANOGUI_HAS_PARENT PARENT_DIRECTORY)
 if(NANOGUI_HAS_PARENT)
-  # This project is included from somewhere else. Export NANOGUI_EXTRA_LIBS variable
-  set(NANOGUI_EXTRA_LIBS ${NANOGUI_EXTRA_LIBS} PARENT_SCOPE)
+  # This project is included from somewhere else. Export NANOGUI_INCLUDE_DIRS and NANOGUI_LIBRARIES variables
+  set(NANOGUI_INCLUDE_DIRS ${nanogui_include_dirs} PARENT_SCOPE)
+  set(NANOGUI_LIBRARIES nanogui ${NANOGUI_EXTRA_LIBS} PARENT_SCOPE)
 endif()
 
 # vim: set et ts=2 sw=2 ft=cmake nospell:

--- a/include/nanogui/formhelper.h
+++ b/include/nanogui/formhelper.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <nanogui/screen.h>
+#include <nanogui/screen_core.h>
 #include <nanogui/label.h>
 #include <nanogui/checkbox.h>
 #include <nanogui/textbox.h>
@@ -61,7 +61,7 @@ NAMESPACE_END(detail)
 class FormHelper {
 public:
     /// Create a helper class to construct NanoGUI widgets on the given screen
-    FormHelper(Screen *screen) : mScreen(screen) { }
+    FormHelper(ScreenCore *screen) : mScreen(screen) { }
 
     /// Add a new top-level window
     Window *addWindow(const Vector2i &pos,
@@ -182,7 +182,7 @@ public:
     void setWidgetFontSize(int value) { mWidgetFontSize = value; }
 
 protected:
-    ref<Screen> mScreen;
+    ref<ScreenCore> mScreen;
     ref<Window> mWindow;
     ref<AdvancedGridLayout> mLayout;
     std::vector<std::function<void()>> mRefreshCallbacks;

--- a/include/nanogui/nanogui.h
+++ b/include/nanogui/nanogui.h
@@ -13,6 +13,7 @@
 
 #include <nanogui/common.h>
 #include <nanogui/widget.h>
+#include <nanogui/screen_core.h>
 #include <nanogui/screen.h>
 #include <nanogui/theme.h>
 #include <nanogui/window.h>

--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -13,7 +13,7 @@
 
 #pragma once
 
-#include <nanogui/widget.h>
+#include <nanogui/screen_core.h>
 
 NAMESPACE_BEGIN(nanogui)
 
@@ -21,9 +21,7 @@ NAMESPACE_BEGIN(nanogui)
  * \brief Represents a display surface (i.e. a full-screen or windowed GLFW window)
  * and forms the root element of a hierarchy of nanogui widgets
  */
-class NANOGUI_EXPORT Screen : public Widget {
-    friend class Widget;
-    friend class Window;
+class NANOGUI_EXPORT Screen : public ScreenCore {
 public:
     /// Create a new screen
     Screen(const Vector2i &size, const std::string &caption,
@@ -59,12 +57,6 @@ public:
     /// Handle a file drop event
     virtual bool dropEvent(const std::vector<std::string> & /* filenames */) { return false; /* To be overridden */ }
 
-    /// Default keyboard event handler
-    virtual bool keyboardEvent(int key, int scancode, int action, int modifiers);
-
-    /// Text input event handler: codepoint is native endian UTF-32 format
-    virtual bool keyboardCharacterEvent(unsigned int codepoint);
-
     /// Window resize event handler
     virtual bool resizeEvent(const Vector2i &) { return false; }
 
@@ -74,16 +66,9 @@ public:
     /// Return a pointer to the underlying GLFW window data structure
     GLFWwindow *glfwWindow() { return mGLFWWindow; }
 
-    /// Return a pointer to the underlying nanoVG draw context
-    NVGcontext *nvgContext() { return mNVGContext; }
-
     void setShutdownGLFWOnDestruct(bool v) { mShutdownGLFWOnDestruct = v; }
     bool shutdownGLFWOnDestruct() { return mShutdownGLFWOnDestruct; }
 
-    /// Compute the layout of all widgets
-    void performLayout() {
-        Widget::performLayout(mNVGContext);
-    }
 public:
     /********* API for applications which manage GLFW themselves *********/
 
@@ -105,39 +90,16 @@ public:
     void initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct);
 
     /* Event handlers */
-    bool cursorPosCallbackEvent(double x, double y);
-    bool mouseButtonCallbackEvent(int button, int action, int modifiers);
-    bool keyCallbackEvent(int key, int scancode, int action, int mods);
-    bool charCallbackEvent(unsigned int codepoint);
     bool dropCallbackEvent(int count, const char **filenames);
-    bool scrollCallbackEvent(double x, double y);
     bool resizeCallbackEvent(int width, int height);
 
-    /* Internal helper functions */
-    void updateFocus(Widget *widget);
-    void disposeWindow(Window *window);
-    void centerWindow(Window *window);
-    void moveWindowToFront(Window *window);
-    void drawWidgets();
-
-    void performLayout(NVGcontext *ctx) {
-        Widget::performLayout(ctx);
-    }
-
 protected:
+    /// Reimplementing this for calling glfwSetCursor()
+    void setCursorGLFW(int c);
+    
     GLFWwindow *mGLFWWindow;
-    NVGcontext *mNVGContext;
     GLFWcursor *mCursors[(int) Cursor::CursorCount];
-    Cursor mCursor;
-    std::vector<Widget *> mFocusPath;
     Vector2i mFBSize;
-    float mPixelRatio;
-    int mMouseState, mModifiers;
-    Vector2i mMousePos;
-    bool mDragActive;
-    Widget *mDragWidget = nullptr;
-    double mLastInteraction;
-    bool mProcessEvents;
     Vector3f mBackground;
     std::string mCaption;
     bool mShutdownGLFWOnDestruct;

--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -93,10 +93,16 @@ public:
     bool dropCallbackEvent(int count, const char **filenames);
     bool resizeCallbackEvent(int width, int height);
 
-protected:
     /// Reimplementing this for calling glfwSetCursor()
-    void setCursorGLFW(int c);
+    void setCursorAppearance(int c);
     
+    /// Reimplement this anc call glfwSetClipboardString() with the string given by the parameter
+    void setCliboardString(const std::string &str);
+    
+    /// Reimplement this anc call glfwGetClipboardString()
+    std::string getClipboardString();
+    
+protected:
     GLFWwindow *mGLFWWindow;
     GLFWcursor *mCursors[(int) Cursor::CursorCount];
     Vector2i mFBSize;

--- a/include/nanogui/screen_core.h
+++ b/include/nanogui/screen_core.h
@@ -87,11 +87,11 @@ public:
     }
 
     /// Reimplement this and call glfwSetCursor() with the cursor type given by the parameter
-    virtual void setCursorGLFW(int) { }
+    virtual void setCursorAppearance(int) { }
     /// Reimplement this anc call glfwSetClipboardString() with the string given by the parameter
     virtual void setCliboardString(const std::string &) { }
     /// Reimplement this anc call glfwGetClipboardString()
-    virtual std::string getClipboardString() { return std::string(); }
+    virtual std::string getClipboardString() { return std::string(); }
 
 protected:    
     NVGcontext *mNVGContext;

--- a/include/nanogui/screen_core.h
+++ b/include/nanogui/screen_core.h
@@ -1,0 +1,105 @@
+/*
+    nanogui/screen_core.h -- Top-level widget
+ 
+    This code has been modified by Giorgio Marcias from the original screen.h
+    in order to allow for NanoGUI screens to be associated to custom GLFW windows
+    having custom callbacks.
+
+    A significant redesign of this code was contributed by Christian Schueller.
+
+    NanoGUI was developed by Wenzel Jakob <wenzel@inf.ethz.ch>.
+    The widget drawing code is based on the NanoVG demo application
+    by Mikko Mononen.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#pragma once
+
+#include <nanogui/window.h>
+#include <nanogui/opengl.h>
+
+NAMESPACE_BEGIN(nanogui)
+
+/**
+ * \brief Forms the root element of a hierarchy of nanogui widgets.
+ */
+class NANOGUI_EXPORT ScreenCore : public Widget {
+protected:
+    friend class Widget;
+    friend class Window;
+public:
+    /**
+     * \brief Default constructor
+     *
+     * Performs no initialization at all. Use this if the application is
+     * responsible for setting up GLFW, OpenGL, etc.
+     *
+     * In this case, override \ref ScreenCore and call \ref initalize().
+     *
+     * You will also be responsible in this case to call the event handlers below.
+     */
+    ScreenCore();
+
+    /// Release all resources
+    virtual ~ScreenCore();
+    
+    /// Initialize the \ref ScreenCore
+    void init(const Vector2i &s, float pRatio);
+
+    /// Set the pixel ratio
+    void setPixelRatio(float pRatio);
+
+    /// Default keyboard event handler
+    virtual bool keyboardEvent(int key, int scancode, int action, int modifiers);
+
+    /// Text input event handler: codepoint is native endian UTF-32 format
+    virtual bool keyboardCharacterEvent(unsigned int codepoint);
+
+    /// Return the last observed mouse position value
+    Vector2i mousePos() const { return mMousePos; }
+
+    /// Return a pointer to the underlying nanoVG draw context
+    NVGcontext *nvgContext() { return mNVGContext; }
+
+    /// Compute the layout of all widgets
+    void performLayout() {
+        Widget::performLayout(mNVGContext);
+    }
+
+    /* Event handlers */
+    bool cursorPosCallbackEvent(double x, double y);
+    bool mouseButtonCallbackEvent(int button, int action, int modifiers);
+    bool keyCallbackEvent(int key, int scancode, int action, int mods);
+    bool charCallbackEvent(unsigned int codepoint);
+    bool scrollCallbackEvent(double x, double y);
+
+    /* Internal helper functions */
+    void updateFocus(Widget *widget);
+    void disposeWindow(Window *window);
+    void centerWindow(Window *window);
+    void moveWindowToFront(Window *window);
+    void drawWidgets();
+
+    void performLayout(NVGcontext *ctx) {
+        Widget::performLayout(ctx);
+    }
+
+protected:
+    /// Reimplement this and call glfwSetCursor() with the cursor type given by the parameter
+    virtual void setCursorGLFW(int) { }
+    
+    NVGcontext *mNVGContext;
+    Cursor mCursor;
+    std::vector<Widget *> mFocusPath;
+    float mPixelRatio;
+    int mMouseState, mModifiers;
+    Vector2i mMousePos;
+    bool mDragActive;
+    Widget *mDragWidget = nullptr;
+    double mLastInteraction;
+    bool mProcessEvents;
+};
+
+NAMESPACE_END(nanogui)

--- a/include/nanogui/screen_core.h
+++ b/include/nanogui/screen_core.h
@@ -86,10 +86,14 @@ public:
         Widget::performLayout(ctx);
     }
 
-protected:
     /// Reimplement this and call glfwSetCursor() with the cursor type given by the parameter
     virtual void setCursorGLFW(int) { }
-    
+    /// Reimplement this anc call glfwSetClipboardString() with the string given by the parameter
+    virtual void setCliboardString(const std::string &) { }
+    /// Reimplement this anc call glfwGetClipboardString()
+    virtual std::string getClipboardString() { return std::string(); }
+
+protected:    
     NVGcontext *mNVGContext;
     Cursor mCursor;
     std::vector<Widget *> mFocusPath;

--- a/include/nanogui/screen_core.h
+++ b/include/nanogui/screen_core.h
@@ -19,6 +19,7 @@
 
 #include <nanogui/window.h>
 #include <nanogui/opengl.h>
+#include <chrono>
 
 NAMESPACE_BEGIN(nanogui)
 
@@ -53,6 +54,13 @@ public:
 
     /// Set the pixel ratio
     void setPixelRatio(float pRatio);
+    
+    /// Set/get the min time before displaying the tooltips
+    void setTooltipDelay(const std::chrono::milliseconds &delay);
+    const std::chrono::milliseconds & getTooltipDelay() const;
+    ///Set/get how long the tooltips must be displayed
+    void setTooltipDuration(const std::chrono::milliseconds &duration);
+    const std::chrono::milliseconds & getTooltipDuration() const;
 
     /// Default keyboard event handler
     virtual bool keyboardEvent(int key, int scancode, int action, int modifiers);
@@ -105,7 +113,9 @@ protected:
     Vector2i mMousePos;
     bool mDragActive;
     Widget *mDragWidget = nullptr;
-    double mLastInteraction;
+    std::chrono::steady_clock::time_point mLastInteraction;
+    std::chrono::milliseconds mTooltipDelay;
+    std::chrono::milliseconds mTooltipDuration;
     bool mProcessEvents;
 };
 

--- a/include/nanogui/window.h
+++ b/include/nanogui/window.h
@@ -33,7 +33,7 @@ public:
     /// Dispose the window
     void dispose();
 
-    /// Center the window in the current \ref Screen
+    /// Center the window in the current \ref ScreenCore
     void center();
 
     /// Draw the window

--- a/python/example1.py
+++ b/python/example1.py
@@ -18,7 +18,7 @@ from nanogui import Color, Screen, Window, GroupLayout, BoxLayout, \
                     PopupButton, CheckBox, MessageDialog, VScrollPanel, \
                     ImagePanel, ImageView, ComboBox, ProgressBar, Slider, \
                     TextBox, ColorWheel, Graph, VectorXf, GridLayout, \
-                    Alignment, Orientation, SizePolicy
+                    Alignment, Orientation
 
 from nanogui import glfw, entypo
 
@@ -136,7 +136,7 @@ class TestApp(Screen):
         img_window.setLayout(GroupLayout());
 
         img = ImageView(img_window)
-        img.setPolicy(SizePolicy.Expand)
+        img.setPolicy(ImageView.SizePolicy.Expand)
         img.setFixedSize(Vector2i(300, 300))
         img.setImage(icons[0][0])
 
@@ -147,9 +147,9 @@ class TestApp(Screen):
 
         def cb(s):
             if s:
-                img.setPolicy(SizePolicy.Expand)
+                img.setPolicy(ImageView.SizePolicy.Expand)
             else:
-                img.setPolicy(SizePolicy.Fixed)
+                img.setPolicy(ImageView.SizePolicy.Fixed)
         img_cb = CheckBox(img_window, "Expand", cb)
         img_cb.setChecked(True)
 

--- a/python/python.cpp
+++ b/python/python.cpp
@@ -472,17 +472,18 @@ PYBIND11_PLUGIN(nanogui) {
         .def("callback", &ImagePanel::callback, D(ImagePanel, callback))
         .def("setCallback", &ImagePanel::setCallback, D(ImagePanel, setCallback));
 
-    py::enum_<ImageView::SizePolicy>(m, "SizePolicy")
-        .value("Fixed", ImageView::SizePolicy::Fixed)
-        .value("Expand", ImageView::SizePolicy::Expand);
-
-    py::class_<PyImageView, ref<PyImageView>>(m, "ImageView", widget, D(ImageView))
+    py::class_<PyImageView, ref<PyImageView>> imageview(m, "ImageView", widget, D(ImageView));
+    imageview
         .alias<ImageView>()
         .def(py::init<Widget *, int, ImageView::SizePolicy>(), py::arg("parent"), py::arg("image") = 0, py::arg("policy") = ImageView::SizePolicy::Fixed, D(ImageView, ImageView))
         .def("image", &ImageView::image, D(ImageView, image))
         .def("setImage", &ImageView::setImage, D(ImageView, setImage))
         .def("policy", &ImageView::policy, D(ImageView, policy))
         .def("setPolicy", &ImageView::setPolicy, D(ImageView, setPolicy));
+
+    py::enum_<ImageView::SizePolicy>(imageview, "SizePolicy")
+        .value("Fixed", ImageView::SizePolicy::Fixed)
+        .value("Expand", ImageView::SizePolicy::Expand);
 
     py::class_<PyComboBox, ref<PyComboBox>>(m, "ComboBox", widget, D(ComboBox))
         .alias<ComboBox>()

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -182,18 +182,40 @@ std::string file_dialog(const std::vector<std::pair<std::string, std::string>> &
     OPENFILENAME ofn;
     ZeroMemory(&ofn, sizeof(OPENFILENAME));
     ofn.lStructSize = sizeof(OPENFILENAME);
-    char tmp = '\0';
-    ofn.lpstrFile = &tmp;
+    char tmp[FILE_DIALOG_MAX_BUFFER];
+    ofn.lpstrFile = tmp;
+    ZeroMemory(tmp, FILE_DIALOG_MAX_BUFFER);
     ofn.nMaxFile = FILE_DIALOG_MAX_BUFFER;
     ofn.nFilterIndex = 1;
 
-    std::vector<char> filter;
-    for (auto pair: filetypes) {
-        for (char c : pair.second)
-            filter.push_back(c);
+    std::string filter;
+
+    if (!save && filetypes.size() > 1) {
+        filter.append("Supported file types (");
+        for (size_t i = 0; i < filetypes.size(); ++i) {
+            filter.append("*.");
+            filter.append(filetypes[i].first);
+            if (i + 1 < filetypes.size())
+                filter.append(";");
+        }
+        filter.append(")");
         filter.push_back('\0');
-        for (char c : pair.first)
-            filter.push_back(c);
+        for (size_t i = 0; i < filetypes.size(); ++i) {
+            filter.append("*.");
+            filter.append(filetypes[i].first);
+            if (i + 1 < filetypes.size())
+                filter.append(";");
+        }
+        filter.push_back('\0');
+    }
+    for (auto pair: filetypes) {
+        filter.append(pair.second);
+        filter.append(" (*.");
+        filter.append(pair.first);
+        filter.append(")");
+        filter.push_back('\0');
+        filter.append("*.");
+        filter.append(pair.first);
         filter.push_back('\0');
     }
     filter.push_back('\0');

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -54,6 +54,7 @@ public:
         new Label(window, "Push buttons", "sans-bold");
 
         Button *b = new Button(window, "Plain button");
+        b->setTooltip(std::string("This is a tooltip"));
         b->setCallback([] { cout << "pushed!" << endl; });
         b = new Button(window, "Styled", ENTYPO_ICON_ROCKET);
         b->setBackgroundColor(Color(0, 0, 255, 25));

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -262,7 +262,6 @@ bool Screen::dropCallbackEvent(int count, const char **filenames) {
 bool Screen::resizeCallbackEvent(int, int) {
     glfwGetWindowSize(mGLFWWindow, &mSize[0], &mSize[1]);
     glfwGetFramebufferSize(mGLFWWindow, &mFBSize[0], &mFBSize[1]);
-    mLastInteraction = std::chrono::steady_clock::now();
     try {
         return resizeEvent(mSize);
     } catch (const std::exception &e) {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -262,7 +262,7 @@ bool Screen::dropCallbackEvent(int count, const char **filenames) {
 bool Screen::resizeCallbackEvent(int, int) {
     glfwGetWindowSize(mGLFWWindow, &mSize[0], &mSize[1]);
     glfwGetFramebufferSize(mGLFWWindow, &mFBSize[0], &mFBSize[1]);
-    mLastInteraction = glfwGetTime();
+    mLastInteraction = std::chrono::steady_clock::now();
     try {
         return resizeEvent(mSize);
     } catch (const std::exception &e) {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -273,8 +273,18 @@ bool Screen::resizeCallbackEvent(int, int) {
     }
 }
 
-void Screen::setCursorGLFW(int c) {
+void Screen::setCursorAppearance(int c) {
     glfwSetCursor(mGLFWWindow, mCursors[c]);
+}
+
+/// Reimplement this anc call glfwSetClipboardString() with the string given by the parameter
+void Screen::setCliboardString(const std::string &str) {
+    glfwSetClipboardString(mGLFWWindow, str.c_str());
+}
+
+/// Reimplement this anc call glfwGetClipboardString()
+std::string Screen::getClipboardString() {
+    return std::string(glfwGetClipboardString(mGLFWWindow));
 }
 
 NAMESPACE_END(nanogui)

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -12,16 +12,9 @@
 */
 
 #include <nanogui/screen.h>
-#include <nanogui/theme.h>
 #include <nanogui/opengl.h>
-#include <nanogui/window.h>
-#include <nanogui/popup.h>
 #include <iostream>
 #include <map>
-
-/* Allow enforcing the GL2 implementation of NanoVG */
-#define NANOVG_GL3_IMPLEMENTATION
-#include <nanovg_gl.h>
 
 NAMESPACE_BEGIN(nanogui)
 
@@ -32,17 +25,15 @@ static bool glewInitialized = false;
 #endif
 
 Screen::Screen()
-    : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
-      mCursor(Cursor::Arrow), mShutdownGLFWOnDestruct(false) {
+    : ScreenCore(), mGLFWWindow(nullptr), mShutdownGLFWOnDestruct(false) {
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
 }
 
 Screen::Screen(const Vector2i &size, const std::string &caption,
                bool resizable, bool fullscreen)
-    : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
-      mCursor(Cursor::Arrow), mCaption(caption), mShutdownGLFWOnDestruct(false) {
+    : ScreenCore(), mGLFWWindow(nullptr), mCaption(caption), mShutdownGLFWOnDestruct(false) {
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
-
+    
     /* Request a forward compatible OpenGL 3.3 core profile context */
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
@@ -86,6 +77,7 @@ Screen::Screen(const Vector2i &size, const std::string &caption,
 #endif
 
     glfwGetFramebufferSize(mGLFWWindow, &mFBSize[0], &mFBSize[1]);
+    mSize = size;
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
     glClearColor(mBackground[0], mBackground[1], mBackground[2], 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
@@ -200,22 +192,9 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
     mShutdownGLFWOnDestruct = shutdownGLFWOnDestruct;
     glfwGetWindowSize(mGLFWWindow, &mSize[0], &mSize[1]);
     glfwGetFramebufferSize(mGLFWWindow, &mFBSize[0], &mFBSize[1]);
-
-#ifdef NDEBUG
-    mNVGContext = nvgCreateGL3(NVG_STENCIL_STROKES | NVG_ANTIALIAS);
-#else
-    mNVGContext = nvgCreateGL3(NVG_STENCIL_STROKES | NVG_ANTIALIAS | NVG_DEBUG);
-#endif
-    if (mNVGContext == nullptr)
-        throw std::runtime_error("Could not initialize NanoVG!");
+    init(mSize, (float)mFBSize[0] / (float)mSize[0]);
 
     mVisible = glfwGetWindowAttrib(window, GLFW_VISIBLE) != 0;
-    mTheme = new Theme(mNVGContext);
-    mMousePos = Vector2i::Zero();
-    mMouseState = mModifiers = 0;
-    mDragActive = false;
-    mLastInteraction = glfwGetTime();
-    mProcessEvents = true;
     mBackground = Vector3f(0.3f, 0.3f, 0.32f);
     __nanogui_screens[mGLFWWindow] = this;
 
@@ -229,8 +208,6 @@ Screen::~Screen() {
         if (mCursors[i])
             glfwDestroyCursor(mCursors[i]);
     }
-    if (mNVGContext)
-        nvgDeleteGL3(mNVGContext);
     if (mGLFWWindow && mShutdownGLFWOnDestruct)
         glfwDestroyWindow(mGLFWWindow);
 }
@@ -261,196 +238,19 @@ void Screen::setSize(const Vector2i &size) {
 void Screen::drawAll() {
     glClearColor(mBackground[0], mBackground[1], mBackground[2], 1.0f);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT | GL_STENCIL_BUFFER_BIT);
-
-    drawContents();
-    drawWidgets();
-
-    glfwSwapBuffers(mGLFWWindow);
-}
-
-void Screen::drawWidgets() {
-    if (!mVisible)
-        return;
-
     glfwMakeContextCurrent(mGLFWWindow);
     glfwGetFramebufferSize(mGLFWWindow, &mFBSize[0], &mFBSize[1]);
     glfwGetWindowSize(mGLFWWindow, &mSize[0], &mSize[1]);
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
+    setPixelRatio((float) mFBSize[0] / (float) mSize[0]);
 
-    /* Calculate pixel ratio for hi-dpi devices. */
-    mPixelRatio = (float) mFBSize[0] / (float) mSize[0];
-    nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
+    drawContents();
+    
+    if (mVisible)
+    
+    drawWidgets();
 
-    draw(mNVGContext);
-
-    double elapsed = glfwGetTime() - mLastInteraction;
-
-    if (elapsed > 0.5f) {
-        /* Draw tooltips */
-        const Widget *widget = findWidget(mMousePos);
-        if (widget && !widget->tooltip().empty()) {
-            int tooltipWidth = 150;
-
-            float bounds[4];
-            nvgFontFace(mNVGContext, "sans");
-            nvgFontSize(mNVGContext, 15.0f);
-            nvgTextAlign(mNVGContext, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
-            nvgTextLineHeight(mNVGContext, 1.1f);
-            Vector2i pos = widget->absolutePosition() +
-                           Vector2i(widget->width() / 2, widget->height() + 10);
-
-            nvgTextBoxBounds(mNVGContext, pos.x(), pos.y(), tooltipWidth,
-                             widget->tooltip().c_str(), nullptr, bounds);
-
-            nvgGlobalAlpha(mNVGContext,
-                           std::min(1.0, 2 * (elapsed - 0.5f)) * 0.8);
-
-            nvgBeginPath(mNVGContext);
-            nvgFillColor(mNVGContext, Color(0, 255));
-            int h = (bounds[2] - bounds[0]) / 2;
-            nvgRoundedRect(mNVGContext, bounds[0] - 4 - h, bounds[1] - 4,
-                           (int) (bounds[2] - bounds[0]) + 8,
-                           (int) (bounds[3] - bounds[1]) + 8, 3);
-
-            int px = (int) ((bounds[2] + bounds[0]) / 2) - h;
-            nvgMoveTo(mNVGContext, px, bounds[1] - 10);
-            nvgLineTo(mNVGContext, px + 7, bounds[1] + 1);
-            nvgLineTo(mNVGContext, px - 7, bounds[1] + 1);
-            nvgFill(mNVGContext);
-
-            nvgFillColor(mNVGContext, Color(255, 255));
-            nvgFontBlur(mNVGContext, 0.0f);
-            nvgTextBox(mNVGContext, pos.x() - h, pos.y(), tooltipWidth,
-                       widget->tooltip().c_str(), nullptr);
-        }
-    }
-
-    nvgEndFrame(mNVGContext);
-}
-
-bool Screen::keyboardEvent(int key, int scancode, int action, int modifiers) {
-    if (mFocusPath.size() > 0) {
-        for (auto it = mFocusPath.rbegin() + 1; it != mFocusPath.rend(); ++it)
-            if ((*it)->focused() && (*it)->keyboardEvent(key, scancode, action, modifiers))
-                return true;
-    }
-
-    return false;
-}
-
-bool Screen::keyboardCharacterEvent(unsigned int codepoint) {
-    if (mFocusPath.size() > 0) {
-        for (auto it = mFocusPath.rbegin() + 1; it != mFocusPath.rend(); ++it)
-            if ((*it)->focused() && (*it)->keyboardCharacterEvent(codepoint))
-                return true;
-    }
-    return false;
-}
-
-bool Screen::cursorPosCallbackEvent(double x, double y) {
-    Vector2i p((int) x, (int) y);
-    bool ret = false;
-    mLastInteraction = glfwGetTime();
-    try {
-        p -= Vector2i(1, 2);
-
-        if (!mDragActive) {
-            Widget *widget = findWidget(p);
-            if (widget != nullptr && widget->cursor() != mCursor) {
-                mCursor = widget->cursor();
-                glfwSetCursor(mGLFWWindow, mCursors[(int) mCursor]);
-            }
-        } else {
-            ret = mDragWidget->mouseDragEvent(
-                p - mDragWidget->parent()->absolutePosition(), p - mMousePos,
-                mMouseState, mModifiers);
-        }
-
-        if (!ret)
-            ret = mouseMotionEvent(p, p - mMousePos, mMouseState, mModifiers);
-
-        mMousePos = p;
-
-        return ret;
-    } catch (const std::exception &e) {
-        std::cerr << "Caught exception in event handler: " << e.what() << std::endl;
-        abort();
-    }
-
-    return false;
-}
-
-bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
-    mModifiers = modifiers;
-    mLastInteraction = glfwGetTime();
-    try {
-        if (mFocusPath.size() > 1) {
-            const Window *window =
-                dynamic_cast<Window *>(mFocusPath[mFocusPath.size() - 2]);
-            if (window && window->modal()) {
-                if (!window->contains(mMousePos))
-                    return false;
-            }
-        }
-
-        if (action == GLFW_PRESS)
-            mMouseState |= 1 << button;
-        else
-            mMouseState &= ~(1 << button);
-
-        auto dropWidget = findWidget(mMousePos);
-        if (mDragActive && action == GLFW_RELEASE &&
-            dropWidget != mDragWidget)
-            mDragWidget->mouseButtonEvent(
-                mMousePos - mDragWidget->parent()->absolutePosition(), button,
-                false, mModifiers);
-
-        if (dropWidget != nullptr && dropWidget->cursor() != mCursor) {
-            mCursor = dropWidget->cursor();
-            glfwSetCursor(mGLFWWindow, mCursors[(int) mCursor]);
-        }
-
-        if (action == GLFW_PRESS && button == GLFW_MOUSE_BUTTON_1) {
-            mDragWidget = findWidget(mMousePos);
-            if (mDragWidget == this)
-                mDragWidget = nullptr;
-            mDragActive = mDragWidget != nullptr;
-            if (!mDragActive)
-                updateFocus(nullptr);
-        } else {
-            mDragActive = false;
-            mDragWidget = nullptr;
-        }
-
-        return mouseButtonEvent(mMousePos, button, action == GLFW_PRESS,
-                                mModifiers);
-    } catch (const std::exception &e) {
-        std::cerr << "Caught exception in event handler: " << e.what() << std::endl;
-        abort();
-    }
-
-    return false;
-}
-
-bool Screen::keyCallbackEvent(int key, int scancode, int action, int mods) {
-    mLastInteraction = glfwGetTime();
-    try {
-        return keyboardEvent(key, scancode, action, mods);
-    } catch (const std::exception &e) {
-        std::cerr << "Caught exception in event handler: " << e.what() << std::endl;
-        abort();
-    }
-}
-
-bool Screen::charCallbackEvent(unsigned int codepoint) {
-    mLastInteraction = glfwGetTime();
-    try {
-        return keyboardCharacterEvent(codepoint);
-    } catch (const std::exception &e) {
-        std::cerr << "Caught exception in event handler: " << e.what()
-                  << std::endl;
-        abort();
-    }
+    glfwSwapBuffers(mGLFWWindow);
 }
 
 bool Screen::dropCallbackEvent(int count, const char **filenames) {
@@ -458,27 +258,6 @@ bool Screen::dropCallbackEvent(int count, const char **filenames) {
     for (int i = 0; i < count; ++i)
         arg[i] = filenames[i];
     return dropEvent(arg);
-}
-
-bool Screen::scrollCallbackEvent(double x, double y) {
-    mLastInteraction = glfwGetTime();
-    try {
-        if (mFocusPath.size() > 1) {
-            const Window *window =
-                dynamic_cast<Window *>(mFocusPath[mFocusPath.size() - 2]);
-            if (window && window->modal()) {
-                if (!window->contains(mMousePos))
-                    return false;
-            }
-        }
-        return scrollEvent(mMousePos, Vector2f(x, y));
-    } catch (const std::exception &e) {
-        std::cerr << "Caught exception in event handler: " << e.what()
-                  << std::endl;
-        abort();
-    }
-
-    return false;
 }
 
 bool Screen::resizeCallbackEvent(int, int) {
@@ -494,63 +273,8 @@ bool Screen::resizeCallbackEvent(int, int) {
     }
 }
 
-void Screen::updateFocus(Widget *widget) {
-    for (auto w: mFocusPath) {
-        if (!w->focused())
-            continue;
-        w->focusEvent(false);
-    }
-    mFocusPath.clear();
-    Widget *window = nullptr;
-    while (widget) {
-        mFocusPath.push_back(widget);
-        if (dynamic_cast<Window *>(widget))
-            window = widget;
-        widget = widget->parent();
-    }
-    for (auto it = mFocusPath.rbegin(); it != mFocusPath.rend(); ++it)
-        (*it)->focusEvent(true);
-
-    if (window)
-        moveWindowToFront((Window *) window);
-}
-
-void Screen::disposeWindow(Window *window) {
-    if (std::find(mFocusPath.begin(), mFocusPath.end(), window) != mFocusPath.end())
-        mFocusPath.clear();
-    if (mDragWidget == window)
-        mDragWidget = nullptr;
-    removeChild(window);
-}
-
-void Screen::centerWindow(Window *window) {
-    if (window->size() == Vector2i::Zero()) {
-        window->setSize(window->preferredSize(mNVGContext));
-        window->performLayout(mNVGContext);
-    }
-    window->setPosition((mSize - window->size()) / 2);
-}
-
-void Screen::moveWindowToFront(Window *window) {
-    mChildren.erase(std::remove(mChildren.begin(), mChildren.end(), window), mChildren.end());
-    mChildren.push_back(window);
-    /* Brute force topological sort (no problem for a few windows..) */
-    bool changed = false;
-    do {
-        size_t baseIndex = 0;
-        for (size_t index = 0; index < mChildren.size(); ++index)
-            if (mChildren[index] == window)
-                baseIndex = index;
-        changed = false;
-        for (size_t index = 0; index < mChildren.size(); ++index) {
-            Popup *pw = dynamic_cast<Popup *>(mChildren[index]);
-            if (pw && pw->parentWindow() == window && index < baseIndex) {
-                moveWindowToFront(pw);
-                changed = true;
-                break;
-            }
-        }
-    } while (changed);
+void Screen::setCursorGLFW(int c) {
+    glfwSetCursor(mGLFWWindow, mCursors[c]);
 }
 
 NAMESPACE_END(nanogui)

--- a/src/screen_core.cpp
+++ b/src/screen_core.cpp
@@ -51,7 +51,7 @@ void ScreenCore::init(const Vector2i &s, float pRatio) {
     mMousePos = Vector2i::Zero();
     mMouseState = mModifiers = 0;
     mDragActive = false;
-    mLastInteraction = std::chrono::steady_clock::now();
+    mLastInteraction = std::chrono::steady_clock::now() - mTooltipDelay - mTooltipDuration;
     mProcessEvents = true;
 }
 
@@ -61,6 +61,7 @@ void ScreenCore::setPixelRatio(float pRatio) {
 
 void ScreenCore::setTooltipDelay(const std::chrono::milliseconds &delay) {
     mTooltipDelay = delay;
+    mLastInteraction -= mTooltipDelay + mTooltipDuration;
 }
 
 const std::chrono::milliseconds & ScreenCore::getTooltipDelay() const {
@@ -69,6 +70,7 @@ const std::chrono::milliseconds & ScreenCore::getTooltipDelay() const {
 
 void ScreenCore::setTooltipDuration(const std::chrono::milliseconds &duration) {
     mTooltipDuration = duration;
+    mLastInteraction -= mTooltipDelay + mTooltipDuration;
 }
 
 const std::chrono::milliseconds & ScreenCore::getTooltipDuration() const {
@@ -180,7 +182,7 @@ bool ScreenCore::cursorPosCallbackEvent(double x, double y) {
 
 bool ScreenCore::mouseButtonCallbackEvent(int button, int action, int modifiers) {
     mModifiers = modifiers;
-    mLastInteraction = std::chrono::steady_clock::now();
+    mLastInteraction -= mTooltipDelay + mTooltipDuration;
     try {
         if (mFocusPath.size() > 1) {
             const Window *window =
@@ -231,7 +233,7 @@ bool ScreenCore::mouseButtonCallbackEvent(int button, int action, int modifiers)
 }
 
 bool ScreenCore::keyCallbackEvent(int key, int scancode, int action, int mods) {
-    mLastInteraction = std::chrono::steady_clock::now();
+    mLastInteraction -= mTooltipDelay + mTooltipDuration;
     try {
         return keyboardEvent(key, scancode, action, mods);
     } catch (const std::exception &e) {
@@ -241,7 +243,7 @@ bool ScreenCore::keyCallbackEvent(int key, int scancode, int action, int mods) {
 }
 
 bool ScreenCore::charCallbackEvent(unsigned int codepoint) {
-    mLastInteraction = std::chrono::steady_clock::now();
+    mLastInteraction -= mTooltipDelay + mTooltipDuration;
     try {
         return keyboardCharacterEvent(codepoint);
     } catch (const std::exception &e) {
@@ -252,7 +254,7 @@ bool ScreenCore::charCallbackEvent(unsigned int codepoint) {
 }
 
 bool ScreenCore::scrollCallbackEvent(double x, double y) {
-    mLastInteraction = std::chrono::steady_clock::now();
+    mLastInteraction -= mTooltipDelay + mTooltipDuration;
     try {
         if (mFocusPath.size() > 1) {
             const Window *window =

--- a/src/screen_core.cpp
+++ b/src/screen_core.cpp
@@ -134,7 +134,7 @@ bool ScreenCore::cursorPosCallbackEvent(double x, double y) {
             Widget *widget = findWidget(p);
             if (widget != nullptr && widget->cursor() != mCursor) {
                 mCursor = widget->cursor();
-                setCursorGLFW((int) mCursor);
+                setCursorAppearance((int) mCursor);
             }
         } else {
             ret = mDragWidget->mouseDragEvent(
@@ -183,7 +183,7 @@ bool ScreenCore::mouseButtonCallbackEvent(int button, int action, int modifiers)
 
         if (dropWidget != nullptr && dropWidget->cursor() != mCursor) {
             mCursor = dropWidget->cursor();
-            setCursorGLFW((int) mCursor);
+            setCursorAppearance((int) mCursor);
         }
 
         if (action == GLFW_PRESS && button == GLFW_MOUSE_BUTTON_1) {

--- a/src/screen_core.cpp
+++ b/src/screen_core.cpp
@@ -1,0 +1,312 @@
+/*
+    src/screen.cpp -- Top-level widget and interface between NanoGUI and GLFW
+
+    A significant redesign of this code was contributed by Christian Schueller.
+
+    NanoGUI was developed by Wenzel Jakob <wenzel@inf.ethz.ch>.
+    The widget drawing code is based on the NanoVG demo application
+    by Mikko Mononen.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#include <nanogui/screen_core.h>
+#include <nanogui/theme.h>
+#include <nanogui/popup.h>
+#include <iostream>
+
+/* Allow enforcing the GL2 implementation of NanoVG */
+#define NANOVG_GL3_IMPLEMENTATION
+#include <nanovg_gl.h>
+
+NAMESPACE_BEGIN(nanogui)
+
+ScreenCore::ScreenCore()
+    : Widget(nullptr), mNVGContext(nullptr), mCursor(Cursor::Arrow) { }
+
+ScreenCore::~ScreenCore() {
+    if (mNVGContext)
+        nvgDeleteGL3(mNVGContext);
+}
+
+void ScreenCore::init(const Vector2i &s, float pRatio) {
+    mSize = s;
+    mPixelRatio = pRatio;
+
+#ifdef NDEBUG
+    mNVGContext = nvgCreateGL3(NVG_STENCIL_STROKES | NVG_ANTIALIAS);
+#else
+    mNVGContext = nvgCreateGL3(NVG_STENCIL_STROKES | NVG_ANTIALIAS | NVG_DEBUG);
+#endif
+    if (mNVGContext == nullptr)
+        throw std::runtime_error("Could not initialize NanoVG!");
+
+    mTheme = new Theme(mNVGContext);
+    mMousePos = Vector2i::Zero();
+    mMouseState = mModifiers = 0;
+    mDragActive = false;
+    mLastInteraction = glfwGetTime();
+    mProcessEvents = true;
+}
+
+void ScreenCore::setPixelRatio(float pRatio) {
+    mPixelRatio = pRatio;
+}
+
+void ScreenCore::drawWidgets() {
+    nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
+
+    draw(mNVGContext);
+
+    double elapsed = glfwGetTime() - mLastInteraction;
+
+    if (elapsed > 0.5f) {
+        /* Draw tooltips */
+        const Widget *widget = findWidget(mMousePos);
+        if (widget && !widget->tooltip().empty()) {
+            int tooltipWidth = 150;
+
+            float bounds[4];
+            nvgFontFace(mNVGContext, "sans");
+            nvgFontSize(mNVGContext, 15.0f);
+            nvgTextAlign(mNVGContext, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+            nvgTextLineHeight(mNVGContext, 1.1f);
+            Vector2i pos = widget->absolutePosition() +
+                           Vector2i(widget->width() / 2, widget->height() + 10);
+
+            nvgTextBoxBounds(mNVGContext, pos.x(), pos.y(), tooltipWidth,
+                             widget->tooltip().c_str(), nullptr, bounds);
+
+            nvgGlobalAlpha(mNVGContext,
+                           std::min(1.0, 2 * (elapsed - 0.5f)) * 0.8);
+
+            nvgBeginPath(mNVGContext);
+            nvgFillColor(mNVGContext, Color(0, 255));
+            int h = (bounds[2] - bounds[0]) / 2;
+            nvgRoundedRect(mNVGContext, bounds[0] - 4 - h, bounds[1] - 4,
+                           (int) (bounds[2] - bounds[0]) + 8,
+                           (int) (bounds[3] - bounds[1]) + 8, 3);
+
+            int px = (int) ((bounds[2] + bounds[0]) / 2) - h;
+            nvgMoveTo(mNVGContext, px, bounds[1] - 10);
+            nvgLineTo(mNVGContext, px + 7, bounds[1] + 1);
+            nvgLineTo(mNVGContext, px - 7, bounds[1] + 1);
+            nvgFill(mNVGContext);
+
+            nvgFillColor(mNVGContext, Color(255, 255));
+            nvgFontBlur(mNVGContext, 0.0f);
+            nvgTextBox(mNVGContext, pos.x() - h, pos.y(), tooltipWidth,
+                       widget->tooltip().c_str(), nullptr);
+        }
+    }
+
+    nvgEndFrame(mNVGContext);
+}
+
+bool ScreenCore::keyboardEvent(int key, int scancode, int action, int modifiers) {
+    if (mFocusPath.size() > 0) {
+        for (auto it = mFocusPath.rbegin() + 1; it != mFocusPath.rend(); ++it)
+            if ((*it)->focused() && (*it)->keyboardEvent(key, scancode, action, modifiers))
+                return true;
+    }
+
+    return false;
+}
+
+bool ScreenCore::keyboardCharacterEvent(unsigned int codepoint) {
+    if (mFocusPath.size() > 0) {
+        for (auto it = mFocusPath.rbegin() + 1; it != mFocusPath.rend(); ++it)
+            if ((*it)->focused() && (*it)->keyboardCharacterEvent(codepoint))
+                return true;
+    }
+    return false;
+}
+
+bool ScreenCore::cursorPosCallbackEvent(double x, double y) {
+    Vector2i p((int) x, (int) y);
+    bool ret = false;
+    mLastInteraction = glfwGetTime();
+    try {
+        p -= Vector2i(1, 2);
+
+        if (!mDragActive) {
+            Widget *widget = findWidget(p);
+            if (widget != nullptr && widget->cursor() != mCursor) {
+                mCursor = widget->cursor();
+                setCursorGLFW((int) mCursor);
+            }
+        } else {
+            ret = mDragWidget->mouseDragEvent(
+                p - mDragWidget->parent()->absolutePosition(), p - mMousePos,
+                mMouseState, mModifiers);
+        }
+
+        if (!ret)
+            ret = mouseMotionEvent(p, p - mMousePos, mMouseState, mModifiers);
+
+        mMousePos = p;
+
+        return ret;
+    } catch (const std::exception &e) {
+        std::cerr << "Caught exception in event handler: " << e.what() << std::endl;
+        abort();
+    }
+
+    return false;
+}
+
+bool ScreenCore::mouseButtonCallbackEvent(int button, int action, int modifiers) {
+    mModifiers = modifiers;
+    mLastInteraction = glfwGetTime();
+    try {
+        if (mFocusPath.size() > 1) {
+            const Window *window =
+                dynamic_cast<Window *>(mFocusPath[mFocusPath.size() - 2]);
+            if (window && window->modal()) {
+                if (!window->contains(mMousePos))
+                    return false;
+            }
+        }
+
+        if (action == GLFW_PRESS)
+            mMouseState |= 1 << button;
+        else
+            mMouseState &= ~(1 << button);
+
+        auto dropWidget = findWidget(mMousePos);
+        if (mDragActive && action == GLFW_RELEASE &&
+            dropWidget != mDragWidget)
+            mDragWidget->mouseButtonEvent(
+                mMousePos - mDragWidget->parent()->absolutePosition(), button,
+                false, mModifiers);
+
+        if (dropWidget != nullptr && dropWidget->cursor() != mCursor) {
+            mCursor = dropWidget->cursor();
+            setCursorGLFW((int) mCursor);
+        }
+
+        if (action == GLFW_PRESS && button == GLFW_MOUSE_BUTTON_1) {
+            mDragWidget = findWidget(mMousePos);
+            if (mDragWidget == this)
+                mDragWidget = nullptr;
+            mDragActive = mDragWidget != nullptr;
+            if (!mDragActive)
+                updateFocus(nullptr);
+        } else {
+            mDragActive = false;
+            mDragWidget = nullptr;
+        }
+
+        return mouseButtonEvent(mMousePos, button, action == GLFW_PRESS,
+                                mModifiers);
+    } catch (const std::exception &e) {
+        std::cerr << "Caught exception in event handler: " << e.what() << std::endl;
+        abort();
+    }
+
+    return false;
+}
+
+bool ScreenCore::keyCallbackEvent(int key, int scancode, int action, int mods) {
+    mLastInteraction = glfwGetTime();
+    try {
+        return keyboardEvent(key, scancode, action, mods);
+    } catch (const std::exception &e) {
+        std::cerr << "Caught exception in event handler: " << e.what() << std::endl;
+        abort();
+    }
+}
+
+bool ScreenCore::charCallbackEvent(unsigned int codepoint) {
+    mLastInteraction = glfwGetTime();
+    try {
+        return keyboardCharacterEvent(codepoint);
+    } catch (const std::exception &e) {
+        std::cerr << "Caught exception in event handler: " << e.what()
+                  << std::endl;
+        abort();
+    }
+}
+
+bool ScreenCore::scrollCallbackEvent(double x, double y) {
+    mLastInteraction = glfwGetTime();
+    try {
+        if (mFocusPath.size() > 1) {
+            const Window *window =
+                dynamic_cast<Window *>(mFocusPath[mFocusPath.size() - 2]);
+            if (window && window->modal()) {
+                if (!window->contains(mMousePos))
+                    return false;
+            }
+        }
+        return scrollEvent(mMousePos, Vector2f(x, y));
+    } catch (const std::exception &e) {
+        std::cerr << "Caught exception in event handler: " << e.what()
+                  << std::endl;
+        abort();
+    }
+
+    return false;
+}
+
+void ScreenCore::updateFocus(Widget *widget) {
+    for (auto w: mFocusPath) {
+        if (!w->focused())
+            continue;
+        w->focusEvent(false);
+    }
+    mFocusPath.clear();
+    Widget *window = nullptr;
+    while (widget) {
+        mFocusPath.push_back(widget);
+        if (dynamic_cast<Window *>(widget))
+            window = widget;
+        widget = widget->parent();
+    }
+    for (auto it = mFocusPath.rbegin(); it != mFocusPath.rend(); ++it)
+        (*it)->focusEvent(true);
+
+    if (window)
+        moveWindowToFront((Window *) window);
+}
+
+void ScreenCore::disposeWindow(Window *window) {
+    if (std::find(mFocusPath.begin(), mFocusPath.end(), window) != mFocusPath.end())
+        mFocusPath.clear();
+    if (mDragWidget == window)
+        mDragWidget = nullptr;
+    removeChild(window);
+}
+
+void ScreenCore::centerWindow(Window *window) {
+    if (window->size() == Vector2i::Zero()) {
+        window->setSize(window->preferredSize(mNVGContext));
+        window->performLayout(mNVGContext);
+    }
+    window->setPosition((mSize - window->size()) / 2);
+}
+
+void ScreenCore::moveWindowToFront(Window *window) {
+    mChildren.erase(std::remove(mChildren.begin(), mChildren.end(), window), mChildren.end());
+    mChildren.push_back(window);
+    /* Brute force topological sort (no problem for a few windows..) */
+    bool changed = false;
+    do {
+        size_t baseIndex = 0;
+        for (size_t index = 0; index < mChildren.size(); ++index)
+            if (mChildren[index] == window)
+                baseIndex = index;
+        changed = false;
+        for (size_t index = 0; index < mChildren.size(); ++index) {
+            Popup *pw = dynamic_cast<Popup *>(mChildren[index]);
+            if (pw && pw->parentWindow() == window && index < baseIndex) {
+                moveWindowToFront(pw);
+                changed = true;
+                break;
+            }
+        }
+    } while (changed);
+}
+
+NAMESPACE_END(nanogui)

--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -13,7 +13,7 @@
 */
 
 #include <nanogui/window.h>
-#include <nanogui/screen.h>
+#include <nanogui/screen_core.h>
 #include <nanogui/textbox.h>
 #include <nanogui/opengl.h>
 #include <nanogui/theme.h>
@@ -418,7 +418,7 @@ bool TextBox::checkFormat(const std::string &input, const std::string &format) {
 
 bool TextBox::copySelection() {
     if (mSelectionPos > -1) {
-        Screen *sc = dynamic_cast<Screen *>(this->window()->parent());
+        ScreenCore *sc = dynamic_cast<ScreenCore *>(this->window()->parent());
 
         int begin = mCursorPos;
         int end = mSelectionPos;
@@ -426,8 +426,7 @@ bool TextBox::copySelection() {
         if (begin > end)
             std::swap(begin, end);
 
-        glfwSetClipboardString(sc->glfwWindow(),
-                               mValueTemp.substr(begin, end).c_str());
+        sc->setCliboardString(mValueTemp.substr(begin, end));
         return true;
     }
 
@@ -435,8 +434,8 @@ bool TextBox::copySelection() {
 }
 
 void TextBox::pasteFromClipboard() {
-    Screen *sc = dynamic_cast<Screen *>(this->window()->parent());
-    std::string str(glfwGetClipboardString(sc->glfwWindow()));
+    ScreenCore *sc = dynamic_cast<ScreenCore *>(this->window()->parent());
+    std::string str = sc->getClipboardString();
     mValueTemp.insert(mCursorPos, str);
 }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -14,7 +14,7 @@
 #include <nanogui/theme.h>
 #include <nanogui/window.h>
 #include <nanogui/opengl.h>
-#include <nanogui/screen.h>
+#include <nanogui/screen_core.h>
 
 NAMESPACE_BEGIN(nanogui)
 
@@ -166,7 +166,7 @@ void Widget::requestFocus() {
     Widget *widget = this;
     while (widget->parent())
         widget = widget->parent();
-    ((Screen *) widget)->updateFocus(this);
+    ((ScreenCore *) widget)->updateFocus(this);
 }
 
 void Widget::draw(NVGcontext *ctx) {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -12,7 +12,7 @@
 #include <nanogui/window.h>
 #include <nanogui/theme.h>
 #include <nanogui/opengl.h>
-#include <nanogui/screen.h>
+#include <nanogui/screen_core.h>
 #include <iostream>
 
 NAMESPACE_BEGIN(nanogui)
@@ -109,14 +109,14 @@ void Window::dispose() {
     Widget *widget = this;
     while (widget->parent())
         widget = widget->parent();
-    ((Screen *) widget)->disposeWindow(this);
+    ((ScreenCore *) widget)->disposeWindow(this);
 }
 
 void Window::center() {
     Widget *widget = this;
     while (widget->parent())
         widget = widget->parent();
-    ((Screen *) widget)->centerWindow(this);
+    ((ScreenCore *) widget)->centerWindow(this);
 }
 
 bool Window::mouseDragEvent(const Vector2i &, const Vector2i &rel,


### PR DESCRIPTION
I needed nanogui without GLFW management as I already have event handlers etc. (see my project GLFWM),  even if Screen already provided callbacks to register for. So I split it into ScreenCore (managing widgets) and Screen (managing GLFW callbacks).
There is also a new time setting for tooltip duration.