### PR TITLE
Fix horizontal box layout of Window

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -29,8 +29,14 @@ BoxLayout::BoxLayout(Orientation orientation, Alignment alignment,
 Vector2i BoxLayout::preferredSize(NVGcontext *ctx, const Widget *widget) const {
     Vector2i size = Vector2i::Constant(2*mMargin);
 
-    if (dynamic_cast<const Window *>(widget))
-        size[1] += widget->theme()->mWindowHeaderHeight - mMargin/2;
+    int axis2Offset = 0;
+    if (dynamic_cast<const Window *>(widget)) {
+        if (mOrientation == Orientation::Vertical) {
+            size[1] += widget->theme()->mWindowHeaderHeight - mMargin/2;
+        } else {
+            axis2Offset = widget->theme()->mWindowHeaderHeight;
+        }
+    }
 
     bool first = true;
     int axis1 = (int) mOrientation, axis2 = ((int) mOrientation + 1)%2;
@@ -49,7 +55,7 @@ Vector2i BoxLayout::preferredSize(NVGcontext *ctx, const Widget *widget) const {
         );
 
         size[axis1] += targetSize[axis1];
-        size[axis2] = std::max(size[axis2], targetSize[axis2] + 2*mMargin);
+        size[axis2] = std::max(size[axis2], targetSize[axis2] + 2*mMargin + axis2Offset);
         first = false;
     }
     return size;
@@ -64,9 +70,15 @@ void BoxLayout::performLayout(NVGcontext *ctx, Widget *widget) const {
 
     int axis1 = (int) mOrientation, axis2 = ((int) mOrientation + 1)%2;
     int position = mMargin;
+    int yOffset = 0;
 
-    if (dynamic_cast<Window *>(widget))
-        position += widget->theme()->mWindowHeaderHeight - mMargin/2;
+    if (dynamic_cast<Window *>(widget)) {
+        if (mOrientation == Orientation::Vertical) {
+            position += widget->theme()->mWindowHeaderHeight - mMargin/2;
+        } else {
+            yOffset = widget->theme()->mWindowHeaderHeight;
+        }
+    }
 
     bool first = true;
     for (auto w : widget->children()) {
@@ -82,22 +94,23 @@ void BoxLayout::performLayout(NVGcontext *ctx, Widget *widget) const {
             fs[0] ? fs[0] : ps[0],
             fs[1] ? fs[1] : ps[1]
         );
-        Vector2i pos = Vector2i::Zero();
+        Vector2i pos(0, yOffset);
+
         pos[axis1] = position;
 
         switch (mAlignment) {
             case Alignment::Minimum:
-                pos[axis2] = mMargin;
+                pos[axis2] += mMargin;
                 break;
             case Alignment::Middle:
-                pos[axis2] = (containerSize[axis2] - targetSize[axis2]) / 2;
+                pos[axis2] += (containerSize[axis2] - yOffset - targetSize[axis2]) / 2;
                 break;
             case Alignment::Maximum:
-                pos[axis2] = containerSize[axis2] - targetSize[axis2] - mMargin;
+                pos[axis2] += containerSize[axis2] - yOffset - targetSize[axis2] - mMargin * 2;
                 break;
             case Alignment::Fill:
-                pos[axis2] = mMargin;
-                targetSize[axis2] = fs[axis2] ? fs[axis2] : containerSize[axis2];
+                pos[axis2] += mMargin;
+                targetSize[axis2] = fs[axis2] ? fs[axis2] : (containerSize[axis2] - yOffset - mMargin * 2);
                 break;
         }
 


### PR DESCRIPTION
When Window objects had horizontal layout, the result was broken.

```cpp
        Window *window2 = new Window(this, "Test widgets");
        window2->setPosition(Vector2i(200, 600));
        window2->setLayout(new BoxLayout(Orientation::Horizontal,
                                       Alignment::Middle, 5, 6));
        new Button(window2, "Info");
        new Button(window2, "Info");
        new Button(window2, "Info");

        window2 = new Window(this, "Test widgets");
        window2->setPosition(Vector2i(400, 600));
        window2->setLayout(new BoxLayout(Orientation::Vertical,
                                       Alignment::Middle, 5, 6));
        new Button(window2, "Info");
        new Button(window2, "Info");
        new Button(window2, "Info");
```

before:

![2015-12-18 11 45 26](https://cloud.githubusercontent.com/assets/564612/11888523/c6eb8726-a581-11e5-9865-81f07540acdf.png)

after:

![2015-12-18 12 20 12](https://cloud.githubusercontent.com/assets/564612/11888526/cd94ad8c-a581-11e5-8dfc-b18960bd3f1e.png)
