### PR TITLE
mTheme accessed in some widget's constructor -- issue #48

### DIFF
--- a/include/nanogui/label.h
+++ b/include/nanogui/label.h
@@ -41,6 +41,9 @@ public:
     /// Set the label color
     void setColor(const Color& color) { mColor = color; }
 
+    /// Set the \ref Theme used to draw this widget
+    virtual void setTheme(Theme *theme) override;
+
     /// Compute the size needed to fully display the label
     virtual Vector2i preferredSize(NVGcontext *ctx) const;
     /// Draw the label

--- a/include/nanogui/textbox.h
+++ b/include/nanogui/textbox.h
@@ -53,6 +53,9 @@ public:
     /// Specify a regular expression specifying valid formats
     void setFormat(const std::string &format) { mFormat = format; }
 
+    /// Set the \ref Theme used to draw this widget
+    virtual void setTheme(Theme *theme) override;
+
     /// Set the change callback
     std::function<bool(const std::string& str)> callback() const { return mCallback; }
     void setCallback(const std::function<bool(const std::string& str)> &callback) { mCallback = callback; }

--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -49,7 +49,12 @@ public:
     /// Return the \ref Theme used to draw this widget
     const Theme *theme() const { return mTheme.get(); }
     /// Set the \ref Theme used to draw this widget
-    void setTheme(Theme *theme) { mTheme = theme; }
+    virtual void setTheme(Theme *theme) {
+        mTheme = theme;
+        for (auto child : mChildren) {
+            child->setTheme(theme);
+        }
+    }
 
     /// Return the position relative to the parent widget
     const Vector2i &position() const { return mPos; }

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -18,8 +18,19 @@ NAMESPACE_BEGIN(nanogui)
 
 Label::Label(Widget *parent, const std::string &caption, const std::string &font, int fontSize)
     : Widget(parent), mCaption(caption), mFont(font) {
-    mFontSize = fontSize < 0 ? mTheme->mStandardFontSize : fontSize;
-    mColor = mTheme->mTextColor;
+    if(mTheme) {
+        mFontSize = mTheme->mStandardFontSize;
+        mColor = mTheme->mTextColor;
+    }
+    if(fontSize >= 0) mFontSize = fontSize;
+}
+
+void Label::setTheme(Theme *theme) {
+    Widget::setTheme(theme);
+    if(mTheme) {
+        mFontSize = mTheme->mStandardFontSize;
+        mColor = mTheme->mTextColor;
+    }
 }
 
 Vector2i Label::preferredSize(NVGcontext *ctx) const {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -210,7 +210,7 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
         throw std::runtime_error("Could not initialize NanoVG!");
 
     mVisible = glfwGetWindowAttrib(window, GLFW_VISIBLE) != 0;
-    mTheme = new Theme(mNVGContext);
+    setTheme(new Theme(mNVGContext));
     mMousePos = Vector2i::Zero();
     mMouseState = mModifiers = 0;
     mDragActive = false;

--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -42,12 +42,17 @@ TextBox::TextBox(Widget *parent,const std::string &value)
       mMouseDownModifier(0),
       mTextOffset(0),
       mLastClick(0) {
-    mFontSize = mTheme->mTextBoxFontSize;
+    if(mTheme) mFontSize = mTheme->mTextBoxFontSize;
 }
 
 void TextBox::setEditable(bool editable) {
     mEditable = editable;
     setCursor(editable ? Cursor::IBeam : Cursor::Arrow);
+}
+
+void TextBox::setTheme(Theme *theme) {
+    Widget::setTheme(theme);
+    if(mTheme) mFontSize = mTheme->mTextBoxFontSize;
 }
 
 Vector2i TextBox::preferredSize(NVGcontext *ctx) const {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -27,7 +27,6 @@ Widget::Widget(Widget *parent)
       mCursor(Cursor::Arrow) {
     if (parent) {
         parent->addChild(this);
-        setTheme(parent->mTheme);
     }
 }
 
@@ -137,6 +136,7 @@ void Widget::addChild(Widget *widget) {
     mChildren.push_back(widget);
     widget->incRef();
     widget->setParent(this);
+    widget->setTheme(mTheme);
 }
 
 void Widget::removeChild(const Widget *widget) {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -27,7 +27,7 @@ Widget::Widget(Widget *parent)
       mCursor(Cursor::Arrow) {
     if (parent) {
         parent->addChild(this);
-        mTheme = parent->mTheme;
+        setTheme(parent->mTheme);
     }
 }
 
@@ -39,7 +39,7 @@ Widget::~Widget() {
 }
 
 int Widget::fontSize() const {
-    return mFontSize < 0 ? mTheme->mStandardFontSize : mFontSize;
+    return (mFontSize < 0 && mTheme) ? mTheme->mStandardFontSize : mFontSize;
 }
 
 Vector2i Widget::preferredSize(NVGcontext *ctx) const {


### PR DESCRIPTION
Unfortunately the `setTheme` method being virtual cannot be used in the Widget constructor, that is why you need to keep setting mFontSize and so on both in constructor and setTheme. The other option would be to remove setThemefron the Widget constructor and call it in every widget's constructors, but in my opinion this is less appropriate.
 