### PR TITLE
Initialize mBackground before first glClearColor call in constructor,…

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -72,15 +72,16 @@ static float get_pixel_ratio(GLFWwindow *window) {
 }
 Screen::Screen()
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
-      mCursor(Cursor::Arrow), mShutdownGLFWOnDestruct(false), mFullscreen(false) {
+      mCursor(Cursor::Arrow), mBackground(0.3f, 0.3f, 0.32f),
+      mShutdownGLFWOnDestruct(false), mFullscreen(false) {
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
 }
 
 Screen::Screen(const Vector2i &size, const std::string &caption,
                bool resizable, bool fullscreen)
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
-      mCursor(Cursor::Arrow), mCaption(caption), mShutdownGLFWOnDestruct(false),
-      mFullscreen(fullscreen) {
+      mCursor(Cursor::Arrow), mBackground(0.3f, 0.3f, 0.32f), mCaption(caption),
+      mShutdownGLFWOnDestruct(false), mFullscreen(fullscreen) {
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
 
     /* Request a forward compatible OpenGL 3.3 core profile context */
@@ -262,7 +263,6 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
     mDragActive = false;
     mLastInteraction = glfwGetTime();
     mProcessEvents = true;
-    mBackground = Vector3f(0.3f, 0.3f, 0.32f);
     __nanogui_screens[mGLFWWindow] = this;
 
     for (int i=0; i < (int) Cursor::CursorCount; ++i)


### PR DESCRIPTION
… remove now redundant call from Screen::initialize.

I was debugging my own program and `valgrind` gives a bunch of `Conditional jump or move depends on uninitialised value(s)` because `glClearColor` is called with `mBackground` before it is initialized.

Issue can be replicated with `example1` in previous commit on master.  I applied it to both constructors, but I'm not entirely sure what the empty constructor is used for so it may not be appropriate.  The `glClearColor` call on line ~130 of `screen.cpp` may not be necessary since `drawAll()` will use it too.

An alternative would be to keep `mBackground` getting set in `initialize()` and just not call clear there?  I'm not sure which is more fitting to the framework / how all of the pieces fit together, but I hope this helps :)