### PR TITLE
Enabling support for alternative core profiles i.e. 4.1. User is resp…

### DIFF
--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -61,7 +61,7 @@ public:
      * \param glMajor
      *    The requested OpenGL Major version number.  Default is 3, if changed
      *    the value must correspond to a forward compatible core profile (for
-     *    portability reasons).  For example, set this to 4 and glMinor to 1
+     *    portability reasons).  For example, set this to 4 and \ref glMinor to 1
      *    for a forward compatible core OpenGL 4.1 profile.  Requesting an
      *    invalid profile will result in no context (and therefore no GUI)
      *    being created.
@@ -69,7 +69,7 @@ public:
      * \param glMinor
      *    The requested OpenGL Minor version number.  Default is 3, if changed
      *    the value must correspond to a forward compatible core profile (for
-     *    portability reasons).  For example, set this to 1 and glMajor to 4
+     *    portability reasons).  For example, set this to 1 and \ref glMajor to 4
      *    for a forward compatible core OpenGL 4.1 profile.  Requesting an
      *    invalid profile will result in no context (and therefore no GUI)
      *    being created.

--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -57,11 +57,28 @@ public:
      *
      * \param nSamples
      *    Number of MSAA samples (set to 0 to disable)
+     *
+     * \param glMajor
+     *    The requested OpenGL Major version number.  Default is 3, if changed
+     *    the value must correspond to a forward compatible core profile (for
+     *    portability reasons).  For example, set this to 4 and glMinor to 1
+     *    for a forward compatible core OpenGL 4.1 profile.  Requesting an
+     *    invalid profile will result in no context (and therefore no GUI)
+     *    being created.
+     *
+     * \param glMinor
+     *    The requested OpenGL Minor version number.  Default is 3, if changed
+     *    the value must correspond to a forward compatible core profile (for
+     *    portability reasons).  For example, set this to 1 and glMajor to 4
+     *    for a forward compatible core OpenGL 4.1 profile.  Requesting an
+     *    invalid profile will result in no context (and therefore no GUI)
+     *    being created.
      */
     Screen(const Vector2i &size, const std::string &caption,
            bool resizable = true, bool fullscreen = false, int colorBits = 8,
            int alphaBits = 8, int depthBits = 24, int stencilBits = 8,
-           int nSamples = 0);
+           int nSamples = 0,
+           unsigned int glMajor = 3, unsigned int glMinor = 3);
 
     /// Release all resources
     virtual ~Screen();

--- a/python/example2.py
+++ b/python/example2.py
@@ -33,7 +33,13 @@ def make_accessors(name):
 
 nanogui.init()
 
-screen = Screen(Vector2i(500, 700), "NanoGUI test")
+use_gl_4_1 = False # Set to True to create an OpenGL 4.1 context.
+if use_gl_4_1:
+    # NanoGUI presents many options for you to utilize at your discretion.
+    # See include/nanogui/screen.h for what all of the options are.
+    screen = Screen(Vector2i(500, 700), "NanoGUI test [GL 4.1]", glMajor=4, glMinor=1)
+else:
+    screen = Screen(Vector2i(500, 700), "NanoGUI test")
 
 gui = FormHelper(screen)
 window = gui.addWindow(Vector2i(10, 10), "Form helper example")

--- a/python/python.cpp
+++ b/python/python.cpp
@@ -419,10 +419,10 @@ PYBIND11_PLUGIN(nanogui) {
 
     py::class_<PyScreen, ref<PyScreen>>(m, "Screen", widget, D(Screen))
         .alias<Screen>()
-        .def(py::init<const Vector2i &, const std::string &, bool, bool, int, int, int, int, int>(),
+        .def(py::init<const Vector2i &, const std::string &, bool, bool, int, int, int, int, int, unsigned int, unsigned int>(),
             py::arg("size"), py::arg("caption"), py::arg("resizable") = true, py::arg("fullscreen") = false,
             py::arg("colorBits") = 8, py::arg("alphaBits") = 8, py::arg("depthBits") = 24, py::arg("stencilBits") = 8,
-            py::arg("nSamples") = 0, D(Screen, Screen))
+            py::arg("nSamples") = 0, py::arg("glMajor") = 3, py::arg("glMinor") = 3, D(Screen, Screen))
         .def("caption", &Screen::caption, D(Screen, caption))
         .def("setCaption", &Screen::setCaption, D(Screen, setCaption))
         .def("background", &Screen::background, D(Screen, background))

--- a/src/example2.cpp
+++ b/src/example2.cpp
@@ -1,5 +1,5 @@
 /*
-    src/example2.cpp -- C++ version of an example application that shows 
+    src/example2.cpp -- C++ version of an example application that shows
     how to use the form helper class. For a Python implementation, see
     '../python/example2.py'.
 
@@ -34,7 +34,20 @@ int main(int /* argc */, char ** /* argv */) {
     nanogui::init();
 
     {
-        Screen *screen = new Screen(Vector2i(500, 700), "NanoGUI test");
+        bool use_gl_4_1 = false;// set to true to create an OpenGL 4.1 context
+        Screen *screen = nullptr;
+
+        if(use_gl_4_1) {
+            // NanoGUI presents many options for you to utilize at your discretion.
+            // see nanogui/screen.h for what all of these represent.
+            screen = new Screen(Vector2i(500, 700), "NanoGUI test [GL 4.1]",
+                                /*resizable*/true, /*fullscreen*/false, /*colorBits*/8,
+                                /*alphaBits*/8, /*depthBits*/24, /*stencilBits*/8,
+                                /*nSamples*/0, /*glMajor*/4, /*glMinor*/1);
+        }
+        else {
+            screen = new Screen(Vector2i(500, 700), "NanoGUI test");
+        }
 
         bool enabled = true;
         FormHelper *gui = new FormHelper(screen);

--- a/src/example2.cpp
+++ b/src/example2.cpp
@@ -34,12 +34,12 @@ int main(int /* argc */, char ** /* argv */) {
     nanogui::init();
 
     {
-        bool use_gl_4_1 = false;// set to true to create an OpenGL 4.1 context
+        bool use_gl_4_1 = false;// Set to true to create an OpenGL 4.1 context.
         Screen *screen = nullptr;
 
         if(use_gl_4_1) {
             // NanoGUI presents many options for you to utilize at your discretion.
-            // see nanogui/screen.h for what all of these represent.
+            // See include/nanogui/screen.h for what all of these represent.
             screen = new Screen(Vector2i(500, 700), "NanoGUI test [GL 4.1]",
                                 /*resizable*/true, /*fullscreen*/false, /*colorBits*/8,
                                 /*alphaBits*/8, /*depthBits*/24, /*stencilBits*/8,

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -79,15 +79,17 @@ Screen::Screen()
 
 Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
                bool fullscreen, int colorBits, int alphaBits, int depthBits,
-               int stencilBits, int nSamples)
+               int stencilBits, int nSamples,
+               unsigned int glMajor, unsigned int glMinor)
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
       mCursor(Cursor::Arrow), mBackground(0.3f, 0.3f, 0.32f), mCaption(caption),
       mShutdownGLFWOnDestruct(false), mFullscreen(fullscreen) {
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
 
-    /* Request a forward compatible OpenGL 3.3 core profile context */
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    /* Request a forward compatible OpenGL glMajor.glMinor core profile context.
+       Default value is an OpenGL 3.3 core profile context. */
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, glMajor);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, glMinor);
     glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
     glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 
@@ -112,7 +114,9 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
     }
 
     if (!mGLFWWindow)
-        throw std::runtime_error("Could not create an OpenGL 3.3 context!");
+        throw std::runtime_error("Could not create an OpenGL " +
+                                 std::to_string(glMajor) + "." +
+                                 std::to_string(glMinor) + " context!");
 
     glfwMakeContextCurrent(mGLFWWindow);
 


### PR DESCRIPTION
…onsible for requesting a forward compatible core profile if changing the default 3.3 core.

I ended up needing certain features for `4.x` and related `ARB` extensions in another project.  I don't really understand the full implications of this form of update so it may not be stable / appropriate to include in the upstream.

1. Default profile requested is still core 3.3.
2. Screen default arguments in constructor can be changed to request e.g. 4.1.
3. Requests for forward compatible and core profile remain as is (and will fail if an invalid profile is requested).
4. A not so clean example of how to use it in `example2`.  There is almost certainly a way to do this using more elegant C++11 features, but I don't know how to only specify two default args at the end.