### PR TITLE
Suppress warnings from external libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,7 @@ if (NANOGUI_USE_GLAD)
     set_source_files_properties("${CMAKE_CURRENT_SOURCE_DIR}/ext/glad/src/glad.c"
       PROPERTIES COMPILE_FLAGS "/wd4055 ")
   endif()
-  include_directories(ext/glad/include)
+  include_directories(SYSTEM ext/glad/include)
   list(APPEND NANOGUI_EXTRA_DEFS -DNANOGUI_GLAD)
   list(APPEND NANOGUI_EXTRA_INCS "${CMAKE_CURRENT_SOURCE_DIR}/ext/glad/include")
 endif()
@@ -147,7 +147,8 @@ elseif(CMAKE_SYSTEM MATCHES "Linux")
   list(APPEND NANOGUI_EXTRA_LIBS GL Xxf86vm Xrandr Xinerama Xcursor Xi X11 pthread dl rt)
 endif()
 
-include_directories(ext/eigen ext/glfw/include ext/nanovg/src include ${CMAKE_CURRENT_BINARY_DIR})
+include_directories(SYSTEM ext/eigen ext/glfw/include ext/nanovg/src)
+include_directories(include ${CMAKE_CURRENT_BINARY_DIR})
 
 # Run simple C converter to put font files into the data segment
 add_executable(bin2c resources/bin2c.c)
@@ -178,7 +179,7 @@ endif()
 if (APPLE)
   # Include coroutine support for running the mainloop in detached mode
   add_definitions(-DCORO_SJLJ)
-  include_directories(ext/coro)
+  include_directories(SYSTEM ext/coro)
   list(APPEND LIBNANOGUI_PYTHON_EXTRA_SOURCE ext/coro/coro.c)
 endif()
 
@@ -309,7 +310,7 @@ if (NANOGUI_BUILD_PYTHON)
   set_target_properties(nanogui PROPERTIES POSITION_INDEPENDENT_CODE ON)
   set_target_properties(glfw_objects PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-  include_directories("ext/pybind11/include" ${PYTHON_INCLUDE_DIR})
+  include_directories(SYSTEM "ext/pybind11/include" ${PYTHON_INCLUDE_DIR})
   add_library(nanogui_python SHARED python/python.cpp python/python.h python/py_doc.h
                                     ${LIBNANOGUI_PYTHON_EXTRA_SOURCE})
   set_target_properties(nanogui_python PROPERTIES OUTPUT_NAME "nanogui")


### PR DESCRIPTION
[Compiling Eigen with modern compilers generates a lot of warnings as `class std::binder2nd` is deprecated](http://stackoverflow.com/questions/30535933/eigen-gcc-5-class-stdbinder2nd-is-deprecated), and [it seems it's fixed in upstream](http://eigen.tuxfamily.org/bz/show_bug.cgi?id=872). So the warnings could be suppressed if `nanogui` use the patched Eigen version. However, I would suggest skipping warnings from external libraries in general because it's their responsibility.

This PR switch `nanogui` to skip the warnings from external libraries using [CMake's `SYSTEM` option in `include_directories`](https://cmake.org/cmake/help/v3.0/command/include_directories.html).