### PR TITLE
quick edit for IntBox, FloatBox and ComboBox

### DIFF
--- a/include/nanogui/combobox.h
+++ b/include/nanogui/combobox.h
@@ -41,6 +41,8 @@ public:
     const std::vector<std::string> &items() const { return mItems; }
     const std::vector<std::string> &itemsShort() const { return mItemsShort; }
 
+    virtual bool scrollEvent(const Vector2i &p, const Vector2f &rel) override;
+
     virtual void save(Serializer &s) const override;
     virtual bool load(Serializer &s) override;
 protected:

--- a/python/example1.py
+++ b/python/example1.py
@@ -261,14 +261,17 @@ class TestApp(Screen):
         floatBox.setFormat("[-]?[0-9]*\\.?[0-9]+")
 
         Label(window, "Positive integer :", "sans-bold")
-        intBox = TextBox(window)
+        intBox = IntBox(window)
         intBox.setEditable(True)
         intBox.setFixedSize(Vector2i(100, 20))
-        intBox.setValue("50")
+        intBox.setValue(50)
         intBox.setUnits("Mhz")
-        intBox.setDefaultValue("0.0")
+        intBox.setDefaultValue("0")
         intBox.setFontSize(16)
         intBox.setFormat("[1-9][0-9]*")
+        intBox.setSpinnable(True)
+        intBox.setMinValue(1)
+        intBox.setValueIncrement(2)
 
         Label(window, "Checkbox :", "sans-bold")
 

--- a/python/example2.py
+++ b/python/example2.py
@@ -50,7 +50,7 @@ gui.addStringVariable("string", *make_accessors("strvar"))
 
 gui.addGroup("Validating fields")
 gui.addIntVariable("int", *make_accessors("ivar"))
-gui.addDoubleVariable("double", *make_accessors("dvar"))
+gui.addDoubleVariable("double", *make_accessors("dvar")).setSpinnable(True)
 
 gui.addGroup("Complex types")
 gui.addEnumVariable("Enumeration", *make_accessors("enumvar")) \

--- a/python/python.cpp
+++ b/python/python.cpp
@@ -721,6 +721,8 @@ PYBIND11_PLUGIN(nanogui) {
             py::arg("value") = std::string("Untitled"), D(TextBox, TextBox))
         .def("editable", &TextBox::editable, D(TextBox, editable))
         .def("setEditable", &TextBox::setEditable, D(TextBox, setEditable))
+        .def("spinnable", &TextBox::spinnable/*, D(TextBox, spinnable)*/)
+        .def("setSpinnable", &TextBox::setSpinnable/*, D(TextBox, setSpinnable)*/)
         .def("value", &TextBox::value, D(TextBox, value))
         .def("setValue", &TextBox::setValue, D(TextBox, setValue))
         .def("defaultValue", &TextBox::defaultValue, D(TextBox, defaultValue))
@@ -746,14 +748,22 @@ PYBIND11_PLUGIN(nanogui) {
         .def("value", &Int64Box::value, D(IntBox, value))
         .def("setValue", (void (Int64Box::*)(int64_t)) &Int64Box::setValue, D(IntBox, setValue))
         .def("setCallback", (void (Int64Box::*)(const std::function<void(int64_t)>&))
-                &Int64Box::setCallback, D(IntBox, setCallback));
+                &Int64Box::setCallback, D(IntBox, setCallback))
+        .def("setValueIncrement", &Int64Box::setValueIncrement/*, D(IntBox, setValueIncrement)*/)
+        .def("setMinValue", &Int64Box::setMinValue/*, D(IntBox, setMinValue)*/)
+        .def("setMaxValue", &Int64Box::setMaxValue/*, D(IntBox, setMaxValue)*/)
+        .def("setMinValue", &Int64Box::setMinMaxValues/*, D(IntBox, setMinMaxValues)*/);
 
     py::class_<DoubleBox, ref<DoubleBox>, PyDoubleBox>(m, "FloatBox", tbox, D(FloatBox))
         .def(py::init<Widget *, double>(), py::arg("parent"), py::arg("value") = 0.0)
         .def("value", &DoubleBox::value, D(FloatBox, value))
-        .def("setValue", (void (DoubleBox::*)(int64_t)) &DoubleBox::setValue, D(FloatBox, setValue))
+        .def("setValue", (void (DoubleBox::*)(double)) &DoubleBox::setValue, D(FloatBox, setValue))
         .def("setCallback", (void (DoubleBox::*)(const std::function<void(double)>&))
-                &DoubleBox::setCallback, D(FloatBox, setCallback));
+                &DoubleBox::setCallback, D(FloatBox, setCallback))
+        .def("setValueIncrement", &DoubleBox::setValueIncrement/*, D(FloatBox, setValueIncrement)*/)
+        .def("setMinValue", &DoubleBox::setMinValue/*, D(FloatBox, setMinValue)*/)
+        .def("setMaxValue", &DoubleBox::setMaxValue/*, D(FloatBox, setMaxValue)*/)
+        .def("setMinValue", &DoubleBox::setMinMaxValues/*, D(FloatBox, setMinMaxValues)*/);
 
     py::class_<ColorWheel, ref<ColorWheel>, PyColorWheel>(m, "ColorWheel", widget, D(ColorWheel))
         .def(py::init<Widget *>(), py::arg("parent"), D(ColorWheel, ColorWheel))

--- a/src/combobox.cpp
+++ b/src/combobox.cpp
@@ -65,6 +65,21 @@ void ComboBox::setItems(const std::vector<std::string> &items, const std::vector
     setSelectedIndex(mSelectedIndex);
 }
 
+bool ComboBox::scrollEvent(const Vector2i &p, const Vector2f &rel) {
+    if (rel.y() < 0) {
+        setSelectedIndex(std::min(mSelectedIndex+1, (int)(items().size()-1)));
+        if (mCallback)
+            mCallback(mSelectedIndex);
+        return true;
+    } else if (rel.y() > 0) {
+        setSelectedIndex(std::max(mSelectedIndex-1, 0));
+        if (mCallback)
+            mCallback(mSelectedIndex);
+        return true;
+    }
+    return Widget::scrollEvent(p, rel);
+}
+
 void ComboBox::save(Serializer &s) const {
     Widget::save(s);
     s.set("items", mItems);

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -306,14 +306,17 @@ public:
 
         {
             new Label(window, "Positive integer :", "sans-bold");
-            textBox = new TextBox(window);
-            textBox->setEditable(true);
-            textBox->setFixedSize(Vector2i(100, 20));
-            textBox->setValue("50");
-            textBox->setUnits("Mhz");
-            textBox->setDefaultValue("0.0");
-            textBox->setFontSize(16);
-            textBox->setFormat("[1-9][0-9]*");
+            auto intBox = new IntBox<int>(window);
+            intBox->setEditable(true);
+            intBox->setFixedSize(Vector2i(100, 20));
+            intBox->setValue(50);
+            intBox->setUnits("Mhz");
+            intBox->setDefaultValue("0");
+            intBox->setFontSize(16);
+            intBox->setFormat("[1-9][0-9]*");
+            intBox->setSpinnable(true);
+            intBox->setMinValue(1);
+            intBox->setValueIncrement(2);
         }
 
         {

--- a/src/example2.cpp
+++ b/src/example2.cpp
@@ -57,9 +57,9 @@ int main(int /* argc */, char ** /* argv */) {
         gui->addVariable("string", strval);
 
         gui->addGroup("Validating fields");
-        gui->addVariable("int", ivar);
+        gui->addVariable("int", ivar)->setSpinnable(true);
         gui->addVariable("float", fvar);
-        gui->addVariable("double", dvar);
+        gui->addVariable("double", dvar)->setSpinnable(true);
 
         gui->addGroup("Complex types");
         gui->addVariable("Enumeration", enumval, enabled)

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -485,7 +485,7 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
             glfwSetCursor(mGLFWWindow, mCursors[(int) mCursor]);
         }
 
-        if (action == GLFW_PRESS && button == GLFW_MOUSE_BUTTON_1) {
+        if (action == GLFW_PRESS && (button == GLFW_MOUSE_BUTTON_1 || button == GLFW_MOUSE_BUTTON_2)) {
             mDragWidget = findWidget(mMousePos);
             if (mDragWidget == this)
                 mDragWidget = nullptr;


### PR DESCRIPTION
Hi Wenzel,

I added some simple features to more quickly edit the value of IntBox, FloatBox and ComboBox using scrolling and dragging which makes it much more convenient than typing a value. Here are the full list:

- added scrollEvent support for ComboBox
- added right dragging control for IntBox and FloatBox (à la Blender)
- added scrollEvent for same effect
- added double right click to reset to default value for TextBox

Let me know if you have some feedback for improvements. You can easily test these features on Example 1 or 2.
Also I did not add the Python bindings for these. When you approve the changes, you or I can add them quickly to the PR.

Thanks,
Romain