### PR TITLE
More resilient `mkdoc` target (imported from wjakob/mitsuba)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,10 +379,25 @@ if(NANOGUI_HAS_PARENT)
   set(NANOGUI_EXTRA_INCS ${NANOGUI_EXTRA_INCS} PARENT_SCOPE)
 else()
   # Create documentation for python plugin (optional target for developers)
+
+  string(REPLACE " " ";" MKDOC_CXX_FLAGS_LIST ${CMAKE_CXX_FLAGS})
+  get_property(MKDOC_INCLUDE_DIRECTORIES DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTORIES)
+  get_property(MKDOC_COMPILE_DEFINITIONS DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY COMPILE_DEFINITIONS)
+
+  foreach (value ${MKDOC_INCLUDE_DIRECTORIES})
+    list(APPEND MKDOC_CXX_FLAGS_LIST -I${value})
+  endforeach()
+
+  foreach (value ${MKDOC_COMPILE_DEFINITIONS})
+    list(APPEND MKDOC_CXX_FLAGS_LIST -D${value})
+  endforeach()
+
   add_custom_target(mkdoc COMMAND
-    python3 ${CMAKE_CURRENT_SOURCE_DIR}/ext/pybind11/tools/mkdoc.py
-    -Iinclude -Iext/nanovg/src -Iext/eigen -Iext/glfw/include
-    ${CMAKE_CURRENT_SOURCE_DIR}/include/nanogui/*.h > ${CMAKE_CURRENT_SOURCE_DIR}/python/py_doc.h)
+    python3 ${PROJECT_SOURCE_DIR}/ext/pybind11/tools/mkdoc.py
+      ${MKDOC_CXX_FLAGS_LIST}
+      ${PROJECT_SOURCE_DIR}/include/nanogui/*.h
+      > ${CMAKE_CURRENT_SOURCE_DIR}/python/py_doc.h)
+
 endif()
 
 # vim: set et ts=2 sw=2 ft=cmake nospell:

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -3,17 +3,19 @@
   Do not edit! These were automatically extracted by mkdoc.py
  */
 
-#define __EXPAND(x)                              x
-#define __COUNT(_1, _2, _3, _4, _5, COUNT, ...)  COUNT
-#define __VA_SIZE(...)                           __EXPAND(__COUNT(__VA_ARGS__, 5, 4, 3, 2, 1))
-#define __CAT1(a, b)                             a ## b
-#define __CAT2(a, b)                             __CAT1(a, b)
-#define __DOC1(n1)                               __doc_##n1
-#define __DOC2(n1, n2)                           __doc_##n1##_##n2
-#define __DOC3(n1, n2, n3)                       __doc_##n1##_##n2##_##n3
-#define __DOC4(n1, n2, n3, n4)                   __doc_##n1##_##n2##_##n3##_##n4
-#define __DOC5(n1, n2, n3, n4, n5)               __doc_##n1##_##n2##_##n3##_##n4_##n5
-#define DOC(...)                                 __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
+#define __EXPAND(x)                                      x
+#define __COUNT(_1, _2, _3, _4, _5, _6, _7, COUNT, ...)  COUNT
+#define __VA_SIZE(...)                                   __EXPAND(__COUNT(__VA_ARGS__, 7, 6, 5, 4, 3, 2, 1))
+#define __CAT1(a, b)                                     a ## b
+#define __CAT2(a, b)                                     __CAT1(a, b)
+#define __DOC1(n1)                                       __doc_##n1
+#define __DOC2(n1, n2)                                   __doc_##n1##_##n2
+#define __DOC3(n1, n2, n3)                               __doc_##n1##_##n2##_##n3
+#define __DOC4(n1, n2, n3, n4)                           __doc_##n1##_##n2##_##n3##_##n4
+#define __DOC5(n1, n2, n3, n4, n5)                       __doc_##n1##_##n2##_##n3##_##n4##_##n5
+#define __DOC6(n1, n2, n3, n4, n5, n6)                   __doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6
+#define __DOC7(n1, n2, n3, n4, n5, n6, n7)               __doc_##n1##_##n2##_##n3##_##n4##_##n5##_##n6##_##n7
+#define DOC(...)                                         __EXPAND(__EXPAND(__CAT2(__DOC, __VA_SIZE(__VA_ARGS__)))(__VA_ARGS__))
 
 #if defined(__GNUG__)
 #pragma GCC diagnostic push
@@ -21,31 +23,34 @@
 #endif
 
 
-static const char *__doc_nanogui_AdvancedGridLayout = 
+static const char *__doc_nanogui_AdvancedGridLayout =
 R"doc(Advanced Grid layout
 
-The is a fancier grid layout with support for items that span multiple rows
-or columns, and per-widget alignment flags. Each row and column
-additionally stores a stretch factor that controls how additional space is
-redistributed. The downside of this flexibility is that a layout anchor
-data structure must be provided for each widget.
+The is a fancier grid layout with support for items that span multiple
+rows or columns, and per-widget alignment flags. Each row and column
+additionally stores a stretch factor that controls how additional
+space is redistributed. The downside of this flexibility is that a
+layout anchor data structure must be provided for each widget.
 
 An example:
 
-<pre> using AdvancedGridLayout::Anchor; Label *label = new Label(window, "A
-label"); // Add a centered label at grid position (1, 5), which spans two
-horizontal cells layout->setAnchor(label, Anchor(1, 5, 2, 1,
-Alignment::Middle, Alignment::Middle)); </pre>
+```
+using AdvancedGridLayout::Anchor;
+  Label *label = new Label(window, "A label");
+  // Add a centered label at grid position (1, 5), which spans two horizontal cells
+  layout->setAnchor(label, Anchor(1, 5, 2, 1, Alignment::Middle, Alignment::Middle));
+```
 
-The grid is initialized with user-specified column and row size vectors
-(which can be expanded later on if desired). If a size value of zero is
-specified for a column or row, the size is set to the maximum preferred
-size of any widgets contained in the same row or column. Any remaining
-space is redistributed according to the row and column stretch factors.
+The grid is initialized with user-specified column and row size
+vectors (which can be expanded later on if desired). If a size value
+of zero is specified for a column or row, the size is set to the
+maximum preferred size of any widgets contained in the same row or
+column. Any remaining space is redistributed according to the row and
+column stretch factors.
 
-The high level usage somewhat resembles the classic HIG layout: https://web
-.archive.org/web/20070813221705/http://www.autel.cz/dmi/tutorial.html
-https://github.com/jaapgeurts/higlayout)doc";
+The high level usage somewhat resembles the classic HIG layout: https:
+//web.archive.org/web/20070813221705/http://www.autel.cz/dmi/tutorial.
+html https://github.com/jaapgeurts/higlayout)doc";
 
 static const char *__doc_nanogui_AdvancedGridLayout_AdvancedGridLayout = R"doc()doc";
 
@@ -58,6 +63,8 @@ static const char *__doc_nanogui_AdvancedGridLayout_Anchor_Anchor_2 = R"doc()doc
 static const char *__doc_nanogui_AdvancedGridLayout_Anchor_Anchor_3 = R"doc()doc";
 
 static const char *__doc_nanogui_AdvancedGridLayout_Anchor_align = R"doc()doc";
+
+static const char *__doc_nanogui_AdvancedGridLayout_Anchor_operator_basic_string = R"doc()doc";
 
 static const char *__doc_nanogui_AdvancedGridLayout_Anchor_pos = R"doc()doc";
 
@@ -101,6 +108,16 @@ static const char *__doc_nanogui_AdvancedGridLayout_setMargin = R"doc()doc";
 
 static const char *__doc_nanogui_AdvancedGridLayout_setRowStretch = R"doc(Set the stretch factor of a given row)doc";
 
+static const char *__doc_nanogui_Alignment = R"doc()doc";
+
+static const char *__doc_nanogui_Alignment_Fill = R"doc()doc";
+
+static const char *__doc_nanogui_Alignment_Maximum = R"doc()doc";
+
+static const char *__doc_nanogui_Alignment_Middle = R"doc()doc";
+
+static const char *__doc_nanogui_Alignment_Minimum = R"doc()doc";
+
 static const char *__doc_nanogui_Arcball = R"doc(Arcball helper class to interactively rotate objects on-screen)doc";
 
 static const char *__doc_nanogui_Arcball_Arcball = R"doc()doc";
@@ -139,15 +156,16 @@ static const char *__doc_nanogui_Arcball_speedFactor = R"doc()doc";
 
 static const char *__doc_nanogui_Arcball_state = R"doc()doc";
 
-static const char *__doc_nanogui_BoxLayout = 
+static const char *__doc_nanogui_BoxLayout =
 R"doc(Simple horizontal/vertical box layout
 
-This widget stacks up a bunch of widgets horizontally or vertically. It
-adds margins around the entire container and a custom spacing between
-adjacent widgets)doc";
+This widget stacks up a bunch of widgets horizontally or vertically.
+It adds margins around the entire container and a custom spacing
+between adjacent widgets)doc";
 
-static const char *__doc_nanogui_BoxLayout_BoxLayout = 
-R"doc(Construct a box layout which packs widgets in the given ``orientation``
+static const char *__doc_nanogui_BoxLayout_BoxLayout =
+R"doc(Construct a box layout which packs widgets in the given
+``orientation``
 
 Parameter ``alignment``:
     Widget alignment perpendicular to the chosen orientation.
@@ -189,6 +207,26 @@ static const char *__doc_nanogui_BoxLayout_spacing = R"doc()doc";
 static const char *__doc_nanogui_Button = R"doc()doc";
 
 static const char *__doc_nanogui_Button_Button = R"doc()doc";
+
+static const char *__doc_nanogui_Button_Flags = R"doc(Flags to specify the button behavior (can be combined with binary OR))doc";
+
+static const char *__doc_nanogui_Button_Flags_NormalButton = R"doc()doc";
+
+static const char *__doc_nanogui_Button_Flags_PopupButton = R"doc()doc";
+
+static const char *__doc_nanogui_Button_Flags_RadioButton = R"doc()doc";
+
+static const char *__doc_nanogui_Button_Flags_ToggleButton = R"doc()doc";
+
+static const char *__doc_nanogui_Button_IconPosition = R"doc()doc";
+
+static const char *__doc_nanogui_Button_IconPosition_Left = R"doc()doc";
+
+static const char *__doc_nanogui_Button_IconPosition_LeftCentered = R"doc()doc";
+
+static const char *__doc_nanogui_Button_IconPosition_Right = R"doc()doc";
+
+static const char *__doc_nanogui_Button_IconPosition_RightCentered = R"doc()doc";
 
 static const char *__doc_nanogui_Button_backgroundColor = R"doc()doc";
 
@@ -322,6 +360,16 @@ static const char *__doc_nanogui_ColorWheel = R"doc()doc";
 
 static const char *__doc_nanogui_ColorWheel_ColorWheel = R"doc()doc";
 
+static const char *__doc_nanogui_ColorWheel_Region = R"doc()doc";
+
+static const char *__doc_nanogui_ColorWheel_Region_Both = R"doc()doc";
+
+static const char *__doc_nanogui_ColorWheel_Region_InnerTriangle = R"doc()doc";
+
+static const char *__doc_nanogui_ColorWheel_Region_None = R"doc()doc";
+
+static const char *__doc_nanogui_ColorWheel_Region_OuterCircle = R"doc()doc";
+
 static const char *__doc_nanogui_ColorWheel_adjustPosition = R"doc()doc";
 
 static const char *__doc_nanogui_ColorWheel_callback = R"doc(Set the change callback)doc";
@@ -362,7 +410,9 @@ static const char *__doc_nanogui_Color_Color_10 = R"doc()doc";
 
 static const char *__doc_nanogui_Color_Color_11 = R"doc()doc";
 
-static const char *__doc_nanogui_Color_Color_12 = R"doc(Construct a color vector from MatrixBase (needed to play nice with Eigen))doc";
+static const char *__doc_nanogui_Color_Color_12 =
+R"doc(Construct a color vector from MatrixBase (needed to play nice with
+Eigen))doc";
 
 static const char *__doc_nanogui_Color_Color_2 = R"doc()doc";
 
@@ -392,6 +442,8 @@ static const char *__doc_nanogui_Color_g_2 = R"doc(Return a reference to the gre
 
 static const char *__doc_nanogui_Color_operator_assign = R"doc(Assign a color vector from MatrixBase (needed to play nice with Eigen))doc";
 
+static const char *__doc_nanogui_Color_operator_const_NVGcolor = R"doc()doc";
+
 static const char *__doc_nanogui_Color_r = R"doc(Return a reference to the red channel)doc";
 
 static const char *__doc_nanogui_Color_r_2 = R"doc(Return a reference to the red channel (const version))doc";
@@ -402,9 +454,9 @@ static const char *__doc_nanogui_ComboBox_ComboBox = R"doc(Create an empty combo
 
 static const char *__doc_nanogui_ComboBox_ComboBox_2 = R"doc(Create a new combo box with the given items)doc";
 
-static const char *__doc_nanogui_ComboBox_ComboBox_3 = 
-R"doc(Create a new combo box with the given items, providing both short and long
-descriptive labels for each item)doc";
+static const char *__doc_nanogui_ComboBox_ComboBox_3 =
+R"doc(Create a new combo box with the given items, providing both short and
+long descriptive labels for each item)doc";
 
 static const char *__doc_nanogui_ComboBox_callback = R"doc()doc";
 
@@ -434,9 +486,25 @@ static const char *__doc_nanogui_ComboBox_setItems_2 = R"doc()doc";
 
 static const char *__doc_nanogui_ComboBox_setSelectedIndex = R"doc()doc";
 
+static const char *__doc_nanogui_Cursor = R"doc()doc";
+
+static const char *__doc_nanogui_Cursor_Arrow = R"doc()doc";
+
+static const char *__doc_nanogui_Cursor_Crosshair = R"doc()doc";
+
+static const char *__doc_nanogui_Cursor_CursorCount = R"doc()doc";
+
+static const char *__doc_nanogui_Cursor_HResize = R"doc()doc";
+
+static const char *__doc_nanogui_Cursor_Hand = R"doc()doc";
+
+static const char *__doc_nanogui_Cursor_IBeam = R"doc()doc";
+
+static const char *__doc_nanogui_Cursor_VResize = R"doc()doc";
+
 static const char *__doc_nanogui_FloatBox = R"doc()doc";
 
-static const char *__doc_nanogui_FloatBox_FloatBox_Scalar_ = R"doc()doc";
+static const char *__doc_nanogui_FloatBox_FloatBox = R"doc()doc";
 
 static const char *__doc_nanogui_FloatBox_mNumberFormat = R"doc()doc";
 
@@ -450,29 +518,35 @@ static const char *__doc_nanogui_FloatBox_setValue = R"doc()doc";
 
 static const char *__doc_nanogui_FloatBox_value = R"doc()doc";
 
-static const char *__doc_nanogui_FormHelper = 
-R"doc(Convenience class to create simple AntTweakBar-style layouts that expose
-variables of various types using NanoGUI widgets
+static const char *__doc_nanogui_FormHelper =
+R"doc(Convenience class to create simple AntTweakBar-style layouts that
+expose variables of various types using NanoGUI widgets
 
 Example:
 
-<pre> [ ... initialize NanoGUI, construct screen ... ]
+```
+[ ... initialize NanoGUI, construct screen ... ]
 
 FormHelper* h = new FormHelper(screen);
 
-// Add a new windows widget h->addWindow(Eigen::Vector2i(10,10),"Menu");
+// Add a new windows widget
+h->addWindow(Eigen::Vector2i(10,10),"Menu");
 
-// Start a new group h->addGroup("Group 1");
+// Start a new group
+h->addGroup("Group 1");
 
-// Expose an integer variable by reference h->addVariable("integer
-variable", aInt);
+// Expose an integer variable by reference
+h->addVariable("integer variable", aInt);
 
-// Expose a float variable via setter/getter functions h->addVariable(
-[&](float value){ aFloat = value; }, [&](){ return *aFloat; }, "float
-variable");
+// Expose a float variable via setter/getter functions
+h->addVariable(
+  [&](float value){ aFloat = value; },
+  [&](){ return *aFloat; },
+  "float variable");
 
-// add a new button h->addButton("Button",[&](){ std::cout << "Button
-pressed" << std::endl; }); </pre>)doc";
+// add a new button
+h->addButton("Button",[&](){ std::cout << "Button pressed" << std::endl; });
+```)doc";
 
 static const char *__doc_nanogui_FormHelper_FormHelper = R"doc(Create a helper class to construct NanoGUI widgets on the given screen)doc";
 
@@ -552,13 +626,15 @@ static const char *__doc_nanogui_GLFramebuffer_bind = R"doc(Bind the framebuffer
 
 static const char *__doc_nanogui_GLFramebuffer_blit = R"doc(Blit the framebuffer object onto the screen)doc";
 
-static const char *__doc_nanogui_GLFramebuffer_downloadTGA = 
-R"doc(Quick and dirty method to write a TGA (32bpp RGBA) file of the framebuffer
-contents for debugging)doc";
+static const char *__doc_nanogui_GLFramebuffer_downloadTGA =
+R"doc(Quick and dirty method to write a TGA (32bpp RGBA) file of the
+framebuffer contents for debugging)doc";
 
 static const char *__doc_nanogui_GLFramebuffer_free = R"doc(Release all associated resources)doc";
 
-static const char *__doc_nanogui_GLFramebuffer_init = R"doc(Create a new framebuffer with the specified size and number of MSAA samples)doc";
+static const char *__doc_nanogui_GLFramebuffer_init =
+R"doc(Create a new framebuffer with the specified size and number of MSAA
+samples)doc";
 
 static const char *__doc_nanogui_GLFramebuffer_mColor = R"doc()doc";
 
@@ -576,7 +652,7 @@ static const char *__doc_nanogui_GLFramebuffer_release = R"doc(Release/unbind th
 
 static const char *__doc_nanogui_GLFramebuffer_samples = R"doc(Return the number of MSAA samples)doc";
 
-static const char *__doc_nanogui_GLShader = 
+static const char *__doc_nanogui_GLShader =
 R"doc(Helper class for compiling and linking OpenGL shaders and uploading
 associated vertex and index buffers from Eigen matrices)doc";
 
@@ -596,7 +672,9 @@ static const char *__doc_nanogui_GLShader_Buffer_version = R"doc()doc";
 
 static const char *__doc_nanogui_GLShader_GLShader = R"doc(Create an unitialized OpenGL shader)doc";
 
-static const char *__doc_nanogui_GLShader_attrib = R"doc(Return the handle of a named shader attribute (-1 if it does not exist))doc";
+static const char *__doc_nanogui_GLShader_attrib =
+R"doc(Return the handle of a named shader attribute (-1 if it does not
+exist))doc";
 
 static const char *__doc_nanogui_GLShader_attribVersion = R"doc(Return the version number of a given attribute)doc";
 
@@ -646,29 +724,59 @@ static const char *__doc_nanogui_GLShader_name = R"doc(Return the name of the sh
 
 static const char *__doc_nanogui_GLShader_resetAttribVersion = R"doc(Reset the version number of a given attribute)doc";
 
-static const char *__doc_nanogui_GLShader_setUniform = R"doc(Initialize a uniform parameter with a 4x4 matrix)doc";
+static const char *__doc_nanogui_GLShader_setUniform = R"doc(Initialize a uniform parameter with a 4x4 matrix (float))doc";
+
+static const char *__doc_nanogui_GLShader_setUniform_10 = R"doc(Initialize a uniform buffer with a uniform buffer object)doc";
 
 static const char *__doc_nanogui_GLShader_setUniform_2 = R"doc(Initialize a uniform parameter with an integer value)doc";
 
-static const char *__doc_nanogui_GLShader_setUniform_3 = R"doc(Initialize a uniform parameter with a float value)doc";
+static const char *__doc_nanogui_GLShader_setUniform_3 = R"doc(Initialize a uniform parameter with a floating point value)doc";
 
-static const char *__doc_nanogui_GLShader_setUniform_4 = R"doc(Initialize a uniform parameter with a 2D vector)doc";
+static const char *__doc_nanogui_GLShader_setUniform_4 = R"doc(Initialize a uniform parameter with a 2D vector (int))doc";
 
-static const char *__doc_nanogui_GLShader_setUniform_5 = R"doc(Initialize a uniform parameter with a 3D vector)doc";
+static const char *__doc_nanogui_GLShader_setUniform_5 = R"doc(Initialize a uniform parameter with a 2D vector (float))doc";
 
-static const char *__doc_nanogui_GLShader_setUniform_6 = R"doc(Initialize a uniform parameter with a 4D vector)doc";
+static const char *__doc_nanogui_GLShader_setUniform_6 = R"doc(Initialize a uniform parameter with a 3D vector (int))doc";
 
-static const char *__doc_nanogui_GLShader_shareAttrib = 
-R"doc(Create a symbolic link to an attribute of another GLShader. This avoids
-duplicating unnecessary data)doc";
+static const char *__doc_nanogui_GLShader_setUniform_7 = R"doc(Initialize a uniform parameter with a 3D vector (float))doc";
+
+static const char *__doc_nanogui_GLShader_setUniform_8 = R"doc(Initialize a uniform parameter with a 4D vector (int))doc";
+
+static const char *__doc_nanogui_GLShader_setUniform_9 = R"doc(Initialize a uniform parameter with a 4D vector (float))doc";
+
+static const char *__doc_nanogui_GLShader_shareAttrib =
+R"doc(Create a symbolic link to an attribute of another GLShader. This
+avoids duplicating unnecessary data)doc";
 
 static const char *__doc_nanogui_GLShader_uniform = R"doc(Return the handle of a uniform attribute (-1 if it does not exist))doc";
 
-static const char *__doc_nanogui_GLShader_uploadAttrib = R"doc(Upload an Eigen matrix as a vertex buffer object (refreshing it as needed))doc";
+static const char *__doc_nanogui_GLShader_uploadAttrib =
+R"doc(Upload an Eigen matrix as a vertex buffer object (refreshing it as
+needed))doc";
 
 static const char *__doc_nanogui_GLShader_uploadAttrib_2 = R"doc()doc";
 
 static const char *__doc_nanogui_GLShader_uploadIndices = R"doc(Upload an index buffer)doc";
+
+static const char *__doc_nanogui_GLUniformBuffer = R"doc(Helper class for creating OpenGL Uniform Buffer objects)doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_GLUniformBuffer = R"doc()doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_bind = R"doc(Bind the uniform buffer to a specific binding point)doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_free = R"doc(Release underlying OpenGL object)doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_getBindingPoint = R"doc(Return the binding point of this uniform buffer)doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_init = R"doc(Create a new uniform buffer)doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_mBindingPoint = R"doc()doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_mID = R"doc()doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_release = R"doc(Release/unbind the uniform buffer)doc";
+
+static const char *__doc_nanogui_GLUniformBuffer_update = R"doc(Update content on the GPU using data)doc";
 
 static const char *__doc_nanogui_Graph = R"doc()doc";
 
@@ -726,14 +834,14 @@ static const char *__doc_nanogui_Graph_values = R"doc()doc";
 
 static const char *__doc_nanogui_Graph_values_2 = R"doc()doc";
 
-static const char *__doc_nanogui_GridLayout = 
+static const char *__doc_nanogui_GridLayout =
 R"doc(Grid layout
 
 Widgets are arranged in a grid that has a fixed grid resolution
-``resolution`` along one of the axes. The layout orientation indicates the
-fixed dimension; widgets are also appended on this axis. The spacing
-between items can be specified per axis. The horizontal/vertical alignment
-can be specified per row and column.)doc";
+``resolution`` along one of the axes. The layout orientation indicates
+the fixed dimension; widgets are also appended on this axis. The
+spacing between items can be specified per axis. The
+horizontal/vertical alignment can be specified per row and column.)doc";
 
 static const char *__doc_nanogui_GridLayout_GridLayout = R"doc(Create a 2-column grid layout by default)doc";
 
@@ -783,15 +891,15 @@ static const char *__doc_nanogui_GridLayout_setSpacing_2 = R"doc()doc";
 
 static const char *__doc_nanogui_GridLayout_spacing = R"doc()doc";
 
-static const char *__doc_nanogui_GroupLayout = 
+static const char *__doc_nanogui_GroupLayout =
 R"doc(Special layout for widgets grouped by labels
 
-This widget resembles a box layout in that it arranges a set of widgets
-vertically. All widgets are indented on the horizontal axis except for
-Label widgets, which are not indented.
+This widget resembles a box layout in that it arranges a set of
+widgets vertically. All widgets are indented on the horizontal axis
+except for Label widgets, which are not indented.
 
-This creates a pleasing layout where a number of widgets are grouped under
-some high-level heading.)doc";
+This creates a pleasing layout where a number of widgets are grouped
+under some high-level heading.)doc";
 
 static const char *__doc_nanogui_GroupLayout_GroupLayout = R"doc()doc";
 
@@ -863,6 +971,12 @@ static const char *__doc_nanogui_ImageView = R"doc()doc";
 
 static const char *__doc_nanogui_ImageView_ImageView = R"doc()doc";
 
+static const char *__doc_nanogui_ImageView_SizePolicy = R"doc()doc";
+
+static const char *__doc_nanogui_ImageView_SizePolicy_Expand = R"doc()doc";
+
+static const char *__doc_nanogui_ImageView_SizePolicy_Fixed = R"doc()doc";
+
 static const char *__doc_nanogui_ImageView_draw = R"doc()doc";
 
 static const char *__doc_nanogui_ImageView_image = R"doc()doc";
@@ -881,7 +995,7 @@ static const char *__doc_nanogui_ImageView_setPolicy = R"doc()doc";
 
 static const char *__doc_nanogui_IntBox = R"doc()doc";
 
-static const char *__doc_nanogui_IntBox_IntBox_Scalar_ = R"doc()doc";
+static const char *__doc_nanogui_IntBox_IntBox = R"doc()doc";
 
 static const char *__doc_nanogui_IntBox_setCallback = R"doc()doc";
 
@@ -889,11 +1003,11 @@ static const char *__doc_nanogui_IntBox_setValue = R"doc()doc";
 
 static const char *__doc_nanogui_IntBox_value = R"doc()doc";
 
-static const char *__doc_nanogui_Label = 
+static const char *__doc_nanogui_Label =
 R"doc(Text label widget
 
-The font and color can be customized. When Widget::setFixedWidth() is used,
-the text is wrapped when it surpasses the specified width)doc";
+The font and color can be customized. When Widget::setFixedWidth() is
+used, the text is wrapped when it surpasses the specified width)doc";
 
 static const char *__doc_nanogui_Label_Label = R"doc()doc";
 
@@ -921,7 +1035,7 @@ static const char *__doc_nanogui_Label_setCaption = R"doc(Set the label's text c
 
 static const char *__doc_nanogui_Label_setColor = R"doc(Set the label color)doc";
 
-static const char *__doc_nanogui_Label_setFont = 
+static const char *__doc_nanogui_Label_setFont =
 R"doc(Set the currently active font (2 are available by default: 'sans' and
 'sans-bold'))doc";
 
@@ -936,6 +1050,14 @@ static const char *__doc_nanogui_Layout_preferredSize = R"doc()doc";
 static const char *__doc_nanogui_MessageDialog = R"doc()doc";
 
 static const char *__doc_nanogui_MessageDialog_MessageDialog = R"doc()doc";
+
+static const char *__doc_nanogui_MessageDialog_Type = R"doc()doc";
+
+static const char *__doc_nanogui_MessageDialog_Type_Information = R"doc()doc";
+
+static const char *__doc_nanogui_MessageDialog_Type_Question = R"doc()doc";
+
+static const char *__doc_nanogui_MessageDialog_Type_Warning = R"doc()doc";
 
 static const char *__doc_nanogui_MessageDialog_callback = R"doc()doc";
 
@@ -955,7 +1077,7 @@ static const char *__doc_nanogui_Object_Object = R"doc(Default constructor)doc";
 
 static const char *__doc_nanogui_Object_Object_2 = R"doc(Copy constructor)doc";
 
-static const char *__doc_nanogui_Object_decRef = 
+static const char *__doc_nanogui_Object_decRef =
 R"doc(Decrease the reference count of the object and possibly deallocate it.
 
 The object will automatically be deallocated once the reference count
@@ -967,7 +1089,13 @@ static const char *__doc_nanogui_Object_incRef = R"doc(Increase the object's ref
 
 static const char *__doc_nanogui_Object_m_refCount = R"doc()doc";
 
-static const char *__doc_nanogui_Popup = 
+static const char *__doc_nanogui_Orientation = R"doc()doc";
+
+static const char *__doc_nanogui_Orientation_Horizontal = R"doc()doc";
+
+static const char *__doc_nanogui_Orientation_Vertical = R"doc()doc";
+
+static const char *__doc_nanogui_Popup =
 R"doc(Popup window for combo boxes, popup buttons, nested dialogs etc.
 
 Usually the Popup instance is constructed by another widget (e.g.
@@ -999,17 +1127,17 @@ static const char *__doc_nanogui_PopupButton_save = R"doc()doc";
 
 static const char *__doc_nanogui_PopupButton_setChevronIcon = R"doc()doc";
 
-static const char *__doc_nanogui_Popup_Popup = 
+static const char *__doc_nanogui_Popup_Popup =
 R"doc(Create a new popup parented to a screen (first argument) and a parent
 window)doc";
 
-static const char *__doc_nanogui_Popup_anchorHeight = 
-R"doc(Return the anchor height; this determines the vertical shift relative to
-the anchor position)doc";
+static const char *__doc_nanogui_Popup_anchorHeight =
+R"doc(Return the anchor height; this determines the vertical shift relative
+to the anchor position)doc";
 
-static const char *__doc_nanogui_Popup_anchorPos = 
-R"doc(Set the anchor position in the parent window; the placement of the popup is
-relative to it)doc";
+static const char *__doc_nanogui_Popup_anchorPos =
+R"doc(Set the anchor position in the parent window; the placement of the
+popup is relative to it)doc";
 
 static const char *__doc_nanogui_Popup_draw = R"doc(Draw the popup window)doc";
 
@@ -1025,21 +1153,21 @@ static const char *__doc_nanogui_Popup_parentWindow = R"doc(Return the parent wi
 
 static const char *__doc_nanogui_Popup_parentWindow_2 = R"doc(Return the parent window of the popup)doc";
 
-static const char *__doc_nanogui_Popup_performLayout = 
-R"doc(Invoke the associated layout generator to properly place child widgets, if
-any)doc";
+static const char *__doc_nanogui_Popup_performLayout =
+R"doc(Invoke the associated layout generator to properly place child
+widgets, if any)doc";
 
 static const char *__doc_nanogui_Popup_refreshRelativePlacement = R"doc(Internal helper function to maintain nested window position values)doc";
 
 static const char *__doc_nanogui_Popup_save = R"doc()doc";
 
-static const char *__doc_nanogui_Popup_setAnchorHeight = 
-R"doc(Set the anchor height; this determines the vertical shift relative to the
-anchor position)doc";
+static const char *__doc_nanogui_Popup_setAnchorHeight =
+R"doc(Set the anchor height; this determines the vertical shift relative to
+the anchor position)doc";
 
-static const char *__doc_nanogui_Popup_setAnchorPos = 
-R"doc(Return the anchor position in the parent window; the placement of the popup
-is relative to it)doc";
+static const char *__doc_nanogui_Popup_setAnchorPos =
+R"doc(Return the anchor position in the parent window; the placement of the
+popup is relative to it)doc";
 
 static const char *__doc_nanogui_ProgressBar = R"doc()doc";
 
@@ -1059,27 +1187,75 @@ static const char *__doc_nanogui_ProgressBar_setValue = R"doc()doc";
 
 static const char *__doc_nanogui_ProgressBar_value = R"doc()doc";
 
-static const char *__doc_nanogui_Screen = 
-R"doc(Represents a display surface (i.e. a full-screen or windowed GLFW window)
-and forms the root element of a hierarchy of nanogui widgets)doc";
+static const char *__doc_nanogui_Screen =
+R"doc(Represents a display surface (i.e. a full-screen or windowed GLFW
+window) and forms the root element of a hierarchy of nanogui widgets)doc";
 
-static const char *__doc_nanogui_Screen_Screen = R"doc(Create a new screen)doc";
+static const char *__doc_nanogui_Screen_Screen =
+R"doc(Create a new Screen instance
 
-static const char *__doc_nanogui_Screen_Screen_2 = 
+Parameter ``size``:
+    Size in pixels at 96 dpi (on high-DPI screens, the actual
+    resolution in terms of hardware pixels may be larger by an integer
+    factor)
+
+Parameter ``caption``:
+    Window title (in UTF-8 encoding)
+
+Parameter ``resizable``:
+    If creating a window, should it be resizable?
+
+Parameter ``fullscreen``:
+    Specifies whether to create a windowed or full-screen view
+
+Parameter ``colorBits``:
+    Number of bits per pixel dedicated to the R/G/B color components
+
+Parameter ``alphaBits``:
+    Number of bits per pixel dedicated to the alpha channel
+
+Parameter ``depthBits``:
+    Number of bits per pixel dedicated to the Z-buffer
+
+Parameter ``stencilBits``:
+    Number of bits per pixel dedicated to the stencil buffer
+    (recommended to set this to 8. NanoVG can draw higher-quality
+    strokes using a stencil buffer)
+
+Parameter ``nSamples``:
+    Number of MSAA samples (set to 0 to disable)
+
+Parameter ``glMajor``:
+    The requested OpenGL Major version number. Default is 3, if
+    changed the value must correspond to a forward compatible core
+    profile (for portability reasons). For example, set this to 4 and
+    glMinor to 1 for a forward compatible core OpenGL 4.1 profile.
+    Requesting an invalid profile will result in no context (and
+    therefore no GUI) being created.
+
+Parameter ``glMinor``:
+    The requested OpenGL Minor version number. Default is 3, if
+    changed the value must correspond to a forward compatible core
+    profile (for portability reasons). For example, set this to 1 and
+    glMajor to 4 for a forward compatible core OpenGL 4.1 profile.
+    Requesting an invalid profile will result in no context (and
+    therefore no GUI) being created.)doc";
+
+static const char *__doc_nanogui_Screen_Screen_2 =
 R"doc(Default constructor
 
 Performs no initialization at all. Use this if the application is
 responsible for setting up GLFW, OpenGL, etc.
 
-In this case, override Screen and call initalize() with a pointer to an
-existing ``GLFWwindow`` instance
+In this case, override Screen and call initalize() with a pointer to
+an existing ``GLFWwindow`` instance
 
-You will also be responsible in this case to deliver GLFW callbacks to the
-appropriate callback event handlers below)doc";
+You will also be responsible in this case to deliver GLFW callbacks to
+the appropriate callback event handlers below)doc";
 
 static const char *__doc_nanogui_Screen_background = R"doc(Return the screen's background color)doc";
 
-static const char *__doc_nanogui_Screen_caption = R"doc(Get the window titlebar caption)doc";
+static const char *__doc_nanogui_Screen_caption = R"doc(Get the window title bar caption)doc";
 
 static const char *__doc_nanogui_Screen_centerWindow = R"doc()doc";
 
@@ -1163,7 +1339,7 @@ static const char *__doc_nanogui_Screen_scrollCallbackEvent = R"doc()doc";
 
 static const char *__doc_nanogui_Screen_setBackground = R"doc(Set the screen's background color)doc";
 
-static const char *__doc_nanogui_Screen_setCaption = R"doc(Set the window titlebar caption)doc";
+static const char *__doc_nanogui_Screen_setCaption = R"doc(Set the window title bar caption)doc";
 
 static const char *__doc_nanogui_Screen_setShutdownGLFWOnDestruct = R"doc()doc";
 
@@ -1222,6 +1398,14 @@ static const char *__doc_nanogui_Slider_setValue = R"doc()doc";
 static const char *__doc_nanogui_Slider_value = R"doc()doc";
 
 static const char *__doc_nanogui_TextBox = R"doc()doc";
+
+static const char *__doc_nanogui_TextBox_Alignment = R"doc()doc";
+
+static const char *__doc_nanogui_TextBox_Alignment_Center = R"doc()doc";
+
+static const char *__doc_nanogui_TextBox_Alignment_Left = R"doc()doc";
+
+static const char *__doc_nanogui_TextBox_Alignment_Right = R"doc()doc";
 
 static const char *__doc_nanogui_TextBox_TextBox = R"doc()doc";
 
@@ -1411,6 +1595,24 @@ static const char *__doc_nanogui_ToolButton = R"doc()doc";
 
 static const char *__doc_nanogui_ToolButton_ToolButton = R"doc()doc";
 
+static const char *__doc_nanogui_UniformBufferStd140 = R"doc()doc";
+
+static const char *__doc_nanogui_UniformBufferStd140_UniformBufferStd140 = R"doc()doc";
+
+static const char *__doc_nanogui_UniformBufferStd140_UniformBufferStd140_2 = R"doc()doc";
+
+static const char *__doc_nanogui_UniformBufferStd140_UniformBufferStd140_3 = R"doc()doc";
+
+static const char *__doc_nanogui_UniformBufferStd140_UniformBufferStd140_4 = R"doc()doc";
+
+static const char *__doc_nanogui_UniformBufferStd140_UniformBufferStd140_5 = R"doc()doc";
+
+static const char *__doc_nanogui_UniformBufferStd140_push_back = R"doc()doc";
+
+static const char *__doc_nanogui_UniformBufferStd140_push_back_2 = R"doc()doc";
+
+static const char *__doc_nanogui_UniformBufferStd140_push_back_3 = R"doc()doc";
+
 static const char *__doc_nanogui_VScrollPanel = R"doc()doc";
 
 static const char *__doc_nanogui_VScrollPanel_VScrollPanel = R"doc()doc";
@@ -1437,22 +1639,23 @@ static const char *__doc_nanogui_VScrollPanel_save = R"doc()doc";
 
 static const char *__doc_nanogui_VScrollPanel_scrollEvent = R"doc()doc";
 
-static const char *__doc_nanogui_Widget = 
+static const char *__doc_nanogui_Widget =
 R"doc(Base class of all widgets
 
-Widget is the base class of all widgets in ``nanogui``. It can also be used
-as an panel to arrange an arbitrary number of child widgets using a layout
-generator (see Layout).)doc";
+Widget is the base class of all widgets in ``nanogui``. It can also be
+used as an panel to arrange an arbitrary number of child widgets using
+a layout generator (see Layout).)doc";
 
 static const char *__doc_nanogui_Widget_Widget = R"doc(Construct a new widget with the given parent widget)doc";
 
 static const char *__doc_nanogui_Widget_absolutePosition = R"doc(Return the absolute position on screen)doc";
 
-static const char *__doc_nanogui_Widget_addChild = 
+static const char *__doc_nanogui_Widget_addChild =
 R"doc(Add a child widget to the current widget
 
 This function almost never needs to be called by hand, since the
-constructor of Widget automatically adds the current widget to its parent)doc";
+constructor of Widget automatically adds the current widget to its
+parent)doc";
 
 static const char *__doc_nanogui_Widget_childCount = R"doc(Return the number of child widgets)doc";
 
@@ -1474,15 +1677,15 @@ static const char *__doc_nanogui_Widget_fixedSize = R"doc(Return the fixed size 
 
 static const char *__doc_nanogui_Widget_fixedWidth = R"doc()doc";
 
-static const char *__doc_nanogui_Widget_focusEvent = 
+static const char *__doc_nanogui_Widget_focusEvent =
 R"doc(Handle a focus change event (default implementation: record the focus
 status, but do nothing))doc";
 
 static const char *__doc_nanogui_Widget_focused = R"doc(Return whether or not this widget is currently focused)doc";
 
-static const char *__doc_nanogui_Widget_fontSize = 
-R"doc(Return current font size. If not set the default of the current theme will
-be returned)doc";
+static const char *__doc_nanogui_Widget_fontSize =
+R"doc(Return current font size. If not set the default of the current theme
+will be returned)doc";
 
 static const char *__doc_nanogui_Widget_hasFontSize = R"doc(Return whether the font size is explicitly specified for this widget)doc";
 
@@ -1530,23 +1733,27 @@ static const char *__doc_nanogui_Widget_mTooltip = R"doc()doc";
 
 static const char *__doc_nanogui_Widget_mVisible = R"doc()doc";
 
-static const char *__doc_nanogui_Widget_mouseButtonEvent = R"doc(Handle a mouse button event (default implementation: propagate to children))doc";
+static const char *__doc_nanogui_Widget_mouseButtonEvent =
+R"doc(Handle a mouse button event (default implementation: propagate to
+children))doc";
 
 static const char *__doc_nanogui_Widget_mouseDragEvent = R"doc(Handle a mouse drag event (default implementation: do nothing))doc";
 
-static const char *__doc_nanogui_Widget_mouseEnterEvent = 
-R"doc(Handle a mouse enter/leave event (default implementation: record this fact,
-but do nothing))doc";
+static const char *__doc_nanogui_Widget_mouseEnterEvent =
+R"doc(Handle a mouse enter/leave event (default implementation: record this
+fact, but do nothing))doc";
 
-static const char *__doc_nanogui_Widget_mouseMotionEvent = R"doc(Handle a mouse motion event (default implementation: propagate to children))doc";
+static const char *__doc_nanogui_Widget_mouseMotionEvent =
+R"doc(Handle a mouse motion event (default implementation: propagate to
+children))doc";
 
 static const char *__doc_nanogui_Widget_parent = R"doc(Return the parent widget)doc";
 
 static const char *__doc_nanogui_Widget_parent_2 = R"doc(Return the parent widget)doc";
 
-static const char *__doc_nanogui_Widget_performLayout = 
-R"doc(Invoke the associated layout generator to properly place child widgets, if
-any)doc";
+static const char *__doc_nanogui_Widget_performLayout =
+R"doc(Invoke the associated layout generator to properly place child
+widgets, if any)doc";
 
 static const char *__doc_nanogui_Widget_position = R"doc(Return the position relative to the parent widget)doc";
 
@@ -1560,7 +1767,9 @@ static const char *__doc_nanogui_Widget_requestFocus = R"doc(Request the focus t
 
 static const char *__doc_nanogui_Widget_save = R"doc(Save the state of the widget into the given Serializer instance)doc";
 
-static const char *__doc_nanogui_Widget_scrollEvent = R"doc(Handle a mouse scroll event (default implementation: propagate to children))doc";
+static const char *__doc_nanogui_Widget_scrollEvent =
+R"doc(Handle a mouse scroll event (default implementation: propagate to
+children))doc";
 
 static const char *__doc_nanogui_Widget_setCursor = R"doc(Set the cursor of the widget)doc";
 
@@ -1568,14 +1777,14 @@ static const char *__doc_nanogui_Widget_setEnabled = R"doc(Set whether or not th
 
 static const char *__doc_nanogui_Widget_setFixedHeight = R"doc(Set the fixed height (see setFixedSize()))doc";
 
-static const char *__doc_nanogui_Widget_setFixedSize = 
+static const char *__doc_nanogui_Widget_setFixedSize =
 R"doc(Set the fixed size of this widget
 
 If nonzero, components of the fixed size attribute override any values
-computed by a layout generator associated with this widget. Note that just
-setting the fixed size alone is not enough to actually change its size;
-this is done with a call to setSize or a call to performLayout() in the
-parent widget.)doc";
+computed by a layout generator associated with this widget. Note that
+just setting the fixed size alone is not enough to actually change its
+size; this is done with a call to setSize or a call to performLayout()
+in the parent widget.)doc";
 
 static const char *__doc_nanogui_Widget_setFixedWidth = R"doc(Set the fixed width (see setFixedSize()))doc";
 
@@ -1599,9 +1808,9 @@ static const char *__doc_nanogui_Widget_setTheme = R"doc(Set the Theme used to d
 
 static const char *__doc_nanogui_Widget_setTooltip = R"doc()doc";
 
-static const char *__doc_nanogui_Widget_setVisible = 
-R"doc(Set whether or not the widget is currently visible (assuming all parents
-are visible))doc";
+static const char *__doc_nanogui_Widget_setVisible =
+R"doc(Set whether or not the widget is currently visible (assuming all
+parents are visible))doc";
 
 static const char *__doc_nanogui_Widget_setWidth = R"doc(Set the width of the widget)doc";
 
@@ -1613,11 +1822,11 @@ static const char *__doc_nanogui_Widget_theme_2 = R"doc(Return the Theme used to
 
 static const char *__doc_nanogui_Widget_tooltip = R"doc()doc";
 
-static const char *__doc_nanogui_Widget_visible = 
-R"doc(Return whether or not the widget is currently visible (assuming all parents
-are visible))doc";
+static const char *__doc_nanogui_Widget_visible =
+R"doc(Return whether or not the widget is currently visible (assuming all
+parents are visible))doc";
 
-static const char *__doc_nanogui_Widget_visibleRecursive = 
+static const char *__doc_nanogui_Widget_visibleRecursive =
 R"doc(Check if this widget is currently visible, taking parent widgets into
 account)doc";
 
@@ -1649,23 +1858,25 @@ static const char *__doc_nanogui_Window_mTitle = R"doc()doc";
 
 static const char *__doc_nanogui_Window_modal = R"doc(Is this a model dialog?)doc";
 
-static const char *__doc_nanogui_Window_mouseButtonEvent = R"doc(Handle mouse events recursively and bring the current window to the top)doc";
+static const char *__doc_nanogui_Window_mouseButtonEvent =
+R"doc(Handle mouse events recursively and bring the current window to the
+top)doc";
 
 static const char *__doc_nanogui_Window_mouseDragEvent = R"doc(Handle window drag events)doc";
 
-static const char *__doc_nanogui_Window_performLayout = 
-R"doc(Invoke the associated layout generator to properly place child widgets, if
-any)doc";
+static const char *__doc_nanogui_Window_performLayout =
+R"doc(Invoke the associated layout generator to properly place child
+widgets, if any)doc";
 
 static const char *__doc_nanogui_Window_preferredSize = R"doc(Compute the preferred size of the widget)doc";
 
-static const char *__doc_nanogui_Window_refreshRelativePlacement = 
+static const char *__doc_nanogui_Window_refreshRelativePlacement =
 R"doc(Internal helper function to maintain nested window position values;
 overridden in Popup)doc";
 
 static const char *__doc_nanogui_Window_save = R"doc()doc";
 
-static const char *__doc_nanogui_Window_scrollEvent = 
+static const char *__doc_nanogui_Window_scrollEvent =
 R"doc(Accept scroll events and propagate them to the widget under the mouse
 cursor)doc";
 
@@ -1675,9 +1886,7 @@ static const char *__doc_nanogui_Window_setTitle = R"doc(Set the window title)do
 
 static const char *__doc_nanogui_Window_title = R"doc(Return the window title)doc";
 
-static const char *__doc_nanogui___nanogui_get_image = R"doc(Helper function used by nvgImageIcon)doc";
-
-static const char *__doc_nanogui_chdir_to_bundle_parent = 
+static const char *__doc_nanogui_chdir_to_bundle_parent =
 R"doc(Move to the application bundle's parent directory
 
 This is function is convenient when deploying .app bundles on OSX. It
@@ -1709,82 +1918,145 @@ static const char *__doc_nanogui_detail_FormWidget_value = R"doc()doc";
 
 static const char *__doc_nanogui_detail_FormWidget_value_2 = R"doc()doc";
 
-static const char *__doc_nanogui_file_dialog = 
+static const char *__doc_nanogui_detail_type_traits = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_2 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_3 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_4 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_5 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_6 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_7 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_8 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_9 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral_2 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral_3 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral_4 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral_5 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral_6 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral_7 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral_8 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_integral_9 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type_2 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type_3 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type_4 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type_5 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type_6 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type_7 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type_8 = R"doc()doc";
+
+static const char *__doc_nanogui_detail_type_traits_type_9 = R"doc()doc";
+
+static const char *__doc_nanogui_file_dialog =
 R"doc(Open a native file open/save dialog.
 
 Parameter ``filetypes``:
-    Pairs of permissible formats with descriptions like ``("png", "Portable
-    Network Graphics")``)doc";
+    Pairs of permissible formats with descriptions like ``("png",
+    "Portable Network Graphics")``)doc";
 
 static const char *__doc_nanogui_frustum = R"doc()doc";
 
-static const char *__doc_nanogui_init = 
-R"doc(Static initialization; should be called once before invoking any NanoGUI
-functions)doc";
+static const char *__doc_nanogui_init =
+R"doc(Static initialization; should be called once before invoking any
+NanoGUI functions)doc";
 
 static const char *__doc_nanogui_leave = R"doc(Request the application main loop to terminate)doc";
 
-static const char *__doc_nanogui_loadImageDirectory = 
-R"doc(Load a directory of PNG images and upload them to the GPU (suitable for use
-with ImagePanel))doc";
+static const char *__doc_nanogui_loadImageDirectory =
+R"doc(Load a directory of PNG images and upload them to the GPU (suitable
+for use with ImagePanel))doc";
 
 static const char *__doc_nanogui_lookAt = R"doc()doc";
 
-static const char *__doc_nanogui_mainloop = 
+static const char *__doc_nanogui_mainloop =
 R"doc(Enter the application main loop
 
 Parameter ``refresh``:
-    NanoGUI issues a redraw call whenever an keyboard/mouse/.. event is
-    received. In the absence of any external events, it enforces a redraw
-    once every ``refresh`` milliseconds. To disable the refresh timer,
-    specify a negative value here.
+    NanoGUI issues a redraw call whenever an keyboard/mouse/.. event
+    is received. In the absence of any external events, it enforces a
+    redraw once every ``refresh`` milliseconds. To disable the refresh
+    timer, specify a negative value here.
 
 Parameter ``detach``:
-    This pararameter only exists in the Python bindings. When the active
-    ``Screen`` instance is provided via the ``detach`` parameter, the
-    ``mainloop()`` function becomes non-blocking and returns immediately
-    (in this case, the main loop runs in parallel on a newly created
-    thread). This feature is convenient for prototyping user interfaces on
-    an interactive Python command prompt.
+    This pararameter only exists in the Python bindings. When the
+    active ``Screen`` instance is provided via the ``detach``
+    parameter, the ``mainloop()`` function becomes non-blocking and
+    returns immediately (in this case, the main loop runs in parallel
+    on a newly created thread). This feature is convenient for
+    prototyping user interfaces on an interactive Python command
+    prompt.
 
-When ``detach != None``, the function returns an opaque handle that will
-release any resources allocated by the created thread when the handle's
-``join()`` method is invoked (or when it is garbage collected).
+When ``detach != None``, the function returns an opaque handle that
+will release any resources allocated by the created thread when the
+handle's ``join()`` method is invoked (or when it is garbage
+collected).
 
 Remark:
-    Unfortunately, Mac OS X strictly requires all event processing to take
-    place on the application's main thread, which is fundamentally
-    incompatible with this type of approach. Thus, NanoGUI relies on a
-    rather crazy workaround on Mac OS (kudos to Dmitriy Morozov):
-    ``mainloop()`` launches a new thread as before but then uses libcoro to
-    swap the thread execution environment (stack, registers, ..) with the
-    main thread. This means that the main application thread is hijacked
-    and processes events in the main loop to satisfy the requirements on
-    Mac OS, while the thread that actually returns from this function is
-    the newly created one (paradoxical, as that may seem). Deleting or
-    ``join()``ing the returned handle causes application to wait for the
-    termination of the main loop and then swap the two thread environments
-    back into their initial configuration.)doc";
+    Unfortunately, Mac OS X strictly requires all event processing to
+    take place on the application's main thread, which is
+    fundamentally incompatible with this type of approach. Thus,
+    NanoGUI relies on a rather crazy workaround on Mac OS (kudos to
+    Dmitriy Morozov): ``mainloop()`` launches a new thread as before
+    but then uses libcoro to swap the thread execution environment
+    (stack, registers, ..) with the main thread. This means that the
+    main application thread is hijacked and processes events in the
+    main loop to satisfy the requirements on Mac OS, while the thread
+    that actually returns from this function is the newly created one
+    (paradoxical, as that may seem). Deleting or ``join()``ing the
+    returned handle causes application to wait for the termination of
+    the main loop and then swap the two thread environments back into
+    their initial configuration.)doc";
 
-static const char *__doc_nanogui_nvgIsFontIcon = 
-R"doc(Determine whether an icon ID is a font-based icon (e.g. from the entypo.ttf
-font))doc";
+static const char *__doc_nanogui_nanogui_get_image = R"doc(Helper function used by nvgImageIcon)doc";
+
+static const char *__doc_nanogui_nvgIsFontIcon =
+R"doc(Determine whether an icon ID is a font-based icon (e.g. from the
+entypo.ttf font))doc";
 
 static const char *__doc_nanogui_nvgIsImageIcon = R"doc(Determine whether an icon ID is a texture loaded via nvgImageIcon)doc";
+
+static const char *__doc_nanogui_operator_const_NVGcolor = R"doc()doc";
 
 static const char *__doc_nanogui_ortho = R"doc()doc";
 
 static const char *__doc_nanogui_project = R"doc()doc";
 
-static const char *__doc_nanogui_ref = 
+static const char *__doc_nanogui_ref =
 R"doc(Reference counting helper
 
-The *ref* refeference template is a simple wrapper to store a pointer to an
-object. It takes care of increasing and decreasing the reference count of
-the object. When the last reference goes out of scope, the associated
-object will be deallocated.
+The *ref* template is a simple wrapper to store a pointer to an
+object. It takes care of increasing and decreasing the object's
+reference count as needed. When the last reference goes out of scope,
+the associated object will be deallocated.
 
-\ingroup libcore)doc";
+The advantage over C++ solutions such as ``std::shared_ptr`` is that
+the reference count is very compactly integrated into the base object
+itself.)doc";
 
 static const char *__doc_nanogui_ref_get = R"doc(Return a const pointer to the referenced object)doc";
 
@@ -1792,11 +2064,15 @@ static const char *__doc_nanogui_ref_get_2 = R"doc(Return a pointer to the refer
 
 static const char *__doc_nanogui_ref_m_ptr = R"doc()doc";
 
+static const char *__doc_nanogui_ref_operator_T0 = R"doc(Return a pointer to the referenced object)doc";
+
 static const char *__doc_nanogui_ref_operator_assign = R"doc(Move another reference into the current one)doc";
 
 static const char *__doc_nanogui_ref_operator_assign_2 = R"doc(Overwrite this reference with another reference)doc";
 
 static const char *__doc_nanogui_ref_operator_assign_3 = R"doc(Overwrite this reference with a pointer to another object)doc";
+
+static const char *__doc_nanogui_ref_operator_bool = R"doc(Check if the object is defined)doc";
 
 static const char *__doc_nanogui_ref_operator_eq = R"doc(Compare this reference with another reference)doc";
 
@@ -1810,17 +2086,17 @@ static const char *__doc_nanogui_ref_operator_ne = R"doc(Compare this reference 
 
 static const char *__doc_nanogui_ref_operator_ne_2 = R"doc(Compare this reference with a pointer)doc";
 
-static const char *__doc_nanogui_ref_operator_sub_ = R"doc(Access the object referenced by this reference)doc";
+static const char *__doc_nanogui_ref_operator_sub = R"doc(Access the object referenced by this reference)doc";
 
-static const char *__doc_nanogui_ref_operator_sub__2 = R"doc(Access the object referenced by this reference)doc";
+static const char *__doc_nanogui_ref_operator_sub_2 = R"doc(Access the object referenced by this reference)doc";
 
-static const char *__doc_nanogui_ref_ref_T_ = R"doc(Create a nullptr reference)doc";
+static const char *__doc_nanogui_ref_ref = R"doc(Create a ``nullptr``-valued reference)doc";
 
-static const char *__doc_nanogui_ref_ref_T__2 = R"doc(Construct a reference from a pointer)doc";
+static const char *__doc_nanogui_ref_ref_2 = R"doc(Construct a reference from a pointer)doc";
 
-static const char *__doc_nanogui_ref_ref_T__3 = R"doc(Copy constructor)doc";
+static const char *__doc_nanogui_ref_ref_3 = R"doc(Copy constructor)doc";
 
-static const char *__doc_nanogui_ref_ref_T__4 = R"doc(Move constructor)doc";
+static const char *__doc_nanogui_ref_ref_4 = R"doc(Move constructor)doc";
 
 static const char *__doc_nanogui_scale = R"doc()doc";
 
@@ -1830,10 +2106,11 @@ static const char *__doc_nanogui_translate = R"doc()doc";
 
 static const char *__doc_nanogui_unproject = R"doc()doc";
 
-static const char *__doc_nanogui_utf8 = 
+static const char *__doc_nanogui_utf8 =
 R"doc(Convert a single UTF32 character code to UTF8
 
-NanoGUI uses this to convert the icon character codes defined in entypo.h)doc";
+NanoGUI uses this to convert the icon character codes defined in
+entypo.h)doc";
 
 #if defined(__GNUG__)
 #pragma GCC diagnostic pop


### PR DESCRIPTION
Python docstrings are also updated to match the current state of the codebase.