### PR TITLE
python.h DECLARE_* macros: scope types

### DIFF
--- a/include/nanogui/python.h
+++ b/include/nanogui/python.h
@@ -11,22 +11,23 @@
 
 #pragma once
 
+#include <nanogui/common.h>
 #include <pybind11/pybind11.h>
 
 #define NANOGUI_WIDGET_OVERLOADS(Parent) \
-    bool mouseButtonEvent(const Vector2i &p, int button, bool down, int modifiers) { \
+    bool mouseButtonEvent(const ::nanogui::Vector2i &p, int button, bool down, int modifiers) { \
         PYBIND11_OVERLOAD(bool, Parent, mouseButtonEvent, p, button, down, modifiers); \
     } \
-    bool mouseMotionEvent(const Vector2i &p, const Vector2i &rel, int button, int modifiers) { \
+    bool mouseMotionEvent(const ::nanogui::Vector2i &p, const ::nanogui::Vector2i &rel, int button, int modifiers) { \
         PYBIND11_OVERLOAD(bool, Parent, mouseMotionEvent, p, rel, button, modifiers); \
     } \
-    bool mouseDragEvent(const Vector2i &p, const Vector2i &rel, int button, int modifiers) { \
+    bool mouseDragEvent(const ::nanogui::Vector2i &p, const ::nanogui::Vector2i &rel, int button, int modifiers) { \
         PYBIND11_OVERLOAD(bool, Parent, mouseDragEvent, p, rel, button, modifiers); \
     } \
-    bool mouseEnterEvent(const Vector2i &p, bool enter) { \
+    bool mouseEnterEvent(const ::nanogui::Vector2i &p, bool enter) { \
         PYBIND11_OVERLOAD(bool, Parent, mouseEnterEvent, p, enter); \
     } \
-    bool scrollEvent(const Vector2i &p, const Vector2f &rel) { \
+    bool scrollEvent(const ::nanogui::Vector2i &p, const ::nanogui::Vector2f &rel) { \
         PYBIND11_OVERLOAD(bool, Parent, scrollEvent, p, rel); \
     } \
     bool focusEvent(bool focused) { \
@@ -38,8 +39,8 @@
     bool keyboardCharacterEvent(unsigned int codepoint) { \
         PYBIND11_OVERLOAD(bool, Parent, keyboardCharacterEvent, codepoint); \
     } \
-    Vector2i preferredSize(NVGcontext *ctx) const { \
-        PYBIND11_OVERLOAD(Vector2i, Parent, preferredSize, ctx); \
+    ::nanogui::Vector2i preferredSize(NVGcontext *ctx) const { \
+        PYBIND11_OVERLOAD(::nanogui::Vector2i, Parent, preferredSize, ctx); \
     } \
     void performLayout(NVGcontext *ctx) { \
         PYBIND11_OVERLOAD(void, Parent, performLayout, ctx); \
@@ -49,10 +50,10 @@
     }
 
 #define NANOGUI_LAYOUT_OVERLOADS(Parent) \
-    Vector2i preferredSize(NVGcontext *ctx, const Widget *widget) const { \
-        PYBIND11_OVERLOAD(Vector2i, Parent, preferredSize, ctx, widget); \
+    ::nanogui::Vector2i preferredSize(NVGcontext *ctx, const ::nanogui::Widget *widget) const { \
+        PYBIND11_OVERLOAD(::nanogui::Vector2i, Parent, preferredSize, ctx, widget); \
     } \
-    void performLayout(NVGcontext *ctx, Widget *widget) const { \
+    void performLayout(NVGcontext *ctx, ::nanogui::Widget *widget) const { \
         PYBIND11_OVERLOAD(void, Parent, performLayout, ctx, widget); \
     }
 
@@ -66,6 +67,6 @@
     virtual bool dropEvent(const std::vector<std::string> &filenames) { \
         PYBIND11_OVERLOAD(bool, Parent, dropEvent, filenames); \
     } \
-    virtual bool resizeEvent(const Vector2i &size) { \
+    virtual bool resizeEvent(const ::nanogui::Vector2i &size) { \
         PYBIND11_OVERLOAD(bool, Parent, resizeEvent, size); \
     }


### PR DESCRIPTION
Note: `NVGcontext` is declared in the global scope in `<nanogui/common.h>`.