### PR TITLE
support for CMAKE_LIBRARY_OUTPUT_DIRECTORY alternate output directory…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,12 +286,13 @@ if (NANOGUI_BUILD_SHARED)
 endif()
 
 if (NANOGUI_BUILD_SHARED AND NOT ${U_CMAKE_BUILD_TYPE} MATCHES DEBUG)
+  # Platform-specific strip flags for reducing the library size.
   if (APPLE)
     # Strip .dylib library on OSX
-    add_custom_command(TARGET nanogui POST_BUILD COMMAND strip -u -r ${CMAKE_CURRENT_BINARY_DIR}/libnanogui.dylib)
+    add_custom_command(TARGET nanogui POST_BUILD COMMAND strip -u -r "$<TARGET_FILE_DIR:nanogui>/$<TARGET_FILE_NAME:nanogui>")
   elseif(UNIX)
     # Strip .so library on Linux
-    add_custom_command(TARGET nanogui POST_BUILD COMMAND strip ${CMAKE_CURRENT_BINARY_DIR}/libnanogui.so)
+    add_custom_command(TARGET nanogui POST_BUILD COMMAND strip "$<TARGET_FILE_DIR:nanogui>/$<TARGET_FILE_NAME:nanogui>")
   endif()
 endif()
 


### PR DESCRIPTION
… on shared library build

Supports alternate library output paths specified, resolves https://github.com/wjakob/nanogui/issues/85

I made a quick example repository to build both:

https://github.com/svenevs/nanogui-strip-test

You should be able to just clone `--recursive` and execute `compile_both.sh`.  It works on OSX, but I am currently traveling and unable to check if it works on Linux...though I don't see why that would fail.