### PR TITLE
Fix screen for applications that want to manage their own glfw and not rely on nanogui

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ endif()
 option(NANOGUI_BUILD_EXAMPLE "Build NanoGUI example application?" ON)
 option(NANOGUI_BUILD_SHARED  "Build NanoGUI as a shared library?" ON)
 option(NANOGUI_BUILD_PYTHON  "Build a Python plugin for NanoGUI?" ON)
-option(NANOGUI_USE_GLAD      "Build a Python plugin for NanoGUI?" ${NANOGUI_USE_GLAD_DEFAULT})
+option(NANOGUI_USE_GLAD      "Use Glad OpenGL loader library?" ${NANOGUI_USE_GLAD_DEFAULT})
 option(NANOGUI_INSTALL       "Install NanoGUI on `make install`?" ON)
 
 set(NANOGUI_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling the Python plugin")
@@ -313,15 +313,17 @@ endif()
 if(NANOGUI_BUILD_EXAMPLE)
   add_executable(example1 src/example1.cpp)
   add_executable(example2 src/example2.cpp)
+  add_executable(example3 src/example3.cpp)
   target_link_libraries(example1 nanogui ${NANOGUI_EXTRA_LIBS})
   target_link_libraries(example2 nanogui ${NANOGUI_EXTRA_LIBS})
+  target_link_libraries(example3 nanogui ${NANOGUI_EXTRA_LIBS})
 
   # Copy icons for example application
   file(COPY resources/icons DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
   if (NANOGUI_INSTALL)
     install(
-      TARGETS example1 example2
+      TARGETS example1 example2 example3
       RUNTIME DESTINATION bin
     )
   endif()

--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -192,7 +192,7 @@ protected:
     std::string mCaption;
     bool mShutdownGLFWOnDestruct;
     bool mFullscreen;
-	bool mOwningGLFWContext;
+    bool mOwningGLFWContext;
 };
 
 NAMESPACE_END(nanogui)

--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -192,6 +192,7 @@ protected:
     std::string mCaption;
     bool mShutdownGLFWOnDestruct;
     bool mFullscreen;
+	bool mOwningGLFWContext;
 };
 
 NAMESPACE_END(nanogui)

--- a/src/example3.cpp
+++ b/src/example3.cpp
@@ -79,12 +79,12 @@ int main(int /* argc */, char ** /* argv */) {
     FormHelper *gui = new FormHelper(screen);
     ref<Window> nanoguiWindow = gui->addWindow(Eigen::Vector2i(10, 10), "Form helper example");
     gui->addGroup("Basic types");
-    gui->addVariable("bool", bvar);
+    gui->addVariable("bool", bvar)->setTooltip("Test tooltip.");
     gui->addVariable("string", strval);
 
     gui->addGroup("Validating fields");
     gui->addVariable("int", ivar)->setSpinnable(true);
-    gui->addVariable("float", fvar);
+    gui->addVariable("float", fvar)->setTooltip("Test.");
     gui->addVariable("double", dvar)->setSpinnable(true);
 
     gui->addGroup("Complex types");
@@ -92,7 +92,7 @@ int main(int /* argc */, char ** /* argv */) {
     gui->addVariable("Color", colval);
 
     gui->addGroup("Other widgets");
-    gui->addButton("A button", []() { std::cout << "Button pressed." << std::endl; });
+    gui->addButton("A button", []() { std::cout << "Button pressed." << std::endl; })->setTooltip("Testing a much longer tooltip, that will wrap around to new lines multiple times.");;
 
     screen->setVisible(true);
     screen->performLayout();

--- a/src/example3.cpp
+++ b/src/example3.cpp
@@ -107,38 +107,38 @@ int main(int /* argc */, char ** /* argv */) {
 
     glfwSetMouseButtonCallback(window,
         [](GLFWwindow *w, int button, int action, int modifiers) {
-        screen->mouseButtonCallbackEvent(button, action, modifiers);
-    }
+            screen->mouseButtonCallbackEvent(button, action, modifiers);
+        }
     );
 
     glfwSetKeyCallback(window,
         [](GLFWwindow *w, int key, int scancode, int action, int mods) {
-        screen->keyCallbackEvent(key, scancode, action, mods);
-    }
+            screen->keyCallbackEvent(key, scancode, action, mods);
+        }
     );
 
     glfwSetCharCallback(window,
         [](GLFWwindow *w, unsigned int codepoint) {
-        screen->charCallbackEvent(codepoint);
-    }
+            screen->charCallbackEvent(codepoint);
+        }
     );
 
     glfwSetDropCallback(window,
         [](GLFWwindow *w, int count, const char **filenames) {
-        screen->dropCallbackEvent(count, filenames);
-    }
+            screen->dropCallbackEvent(count, filenames);
+        }
     );
 
     glfwSetScrollCallback(window,
         [](GLFWwindow *w, double x, double y) {
-        screen->scrollCallbackEvent(x, y);
-    }
+            screen->scrollCallbackEvent(x, y);
+       }
     );
 
     glfwSetFramebufferSizeCallback(window,
         [](GLFWwindow* w, int width, int height) {
-        screen->resizeCallbackEvent(width, height);
-    }
+            screen->resizeCallbackEvent(width, height);
+        }
     );
 
     // Game loop

--- a/src/example3.cpp
+++ b/src/example3.cpp
@@ -1,0 +1,163 @@
+/*
+    src/example3.cpp -- C++ version of an example application that shows
+    how to use nanogui in an application with an already created and managed
+    glfw context.
+
+    NanoGUI was developed by Wenzel Jakob <wenzel.jakob@epfl.ch>.
+    The widget drawing code is based on the NanoVG demo application
+    by Mikko Mononen.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+// GLFW
+#include <GLFW/glfw3.h>
+
+#include <nanogui/nanogui.h>
+#include <iostream>
+
+using namespace nanogui;
+
+enum test_enum {
+    Item1 = 0,
+    Item2,
+    Item3
+};
+
+bool bvar = true;
+int ivar = 12345678;
+double dvar = 3.1415926;
+float fvar = (float)dvar;
+std::string strval = "A string";
+test_enum enumval = Item2;
+Color colval(0.5f, 0.5f, 0.7f, 1.f);
+
+Screen *screen = nullptr;
+
+int main(int /* argc */, char ** /* argv */) {
+
+    glfwInit();
+
+    glfwSetTime(0);
+
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+    glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+    glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+    glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+
+    glfwWindowHint(GLFW_SAMPLES, 0);
+    glfwWindowHint(GLFW_RED_BITS, 8);
+    glfwWindowHint(GLFW_GREEN_BITS, 8);
+    glfwWindowHint(GLFW_BLUE_BITS, 8);
+    glfwWindowHint(GLFW_ALPHA_BITS, 8);
+    glfwWindowHint(GLFW_STENCIL_BITS, 8);
+    glfwWindowHint(GLFW_DEPTH_BITS, 24);
+    glfwWindowHint(GLFW_RESIZABLE, GL_TRUE);
+
+    // Create a GLFWwindow object
+    GLFWwindow* window = glfwCreateWindow(800, 800, "example3", nullptr, nullptr);
+    if (window == nullptr) {
+        std::cout << "Failed to create GLFW window" << std::endl;
+        glfwTerminate();
+        return -1;
+    }
+    glfwMakeContextCurrent(window);
+
+    int width, height;
+    glfwGetFramebufferSize(window, &width, &height);
+    glViewport(0, 0, width, height);
+    glfwSwapInterval(0);
+    glfwSwapBuffers(window);
+
+    // Create a nanogui screen and pass the glfw pointer to initialize
+    screen = new Screen();
+    screen->initialize(window, true);
+
+    // Create nanogui gui
+    bool enabled = true;
+    FormHelper *gui = new FormHelper(screen);
+    ref<Window> nanoguiWindow = gui->addWindow(Eigen::Vector2i(10, 10), "Form helper example");
+    gui->addGroup("Basic types");
+    gui->addVariable("bool", bvar);
+    gui->addVariable("string", strval);
+
+    gui->addGroup("Validating fields");
+    gui->addVariable("int", ivar)->setSpinnable(true);
+    gui->addVariable("float", fvar);
+    gui->addVariable("double", dvar)->setSpinnable(true);
+
+    gui->addGroup("Complex types");
+    gui->addVariable("Enumeration", enumval, enabled)->setItems({ "Item 1", "Item 2", "Item 3" });
+    gui->addVariable("Color", colval);
+
+    gui->addGroup("Other widgets");
+    gui->addButton("A button", []() { std::cout << "Button pressed." << std::endl; });
+
+    screen->setVisible(true);
+    screen->performLayout();
+    nanoguiWindow->center();
+
+
+    glfwSetCursorPosCallback(window,
+        [](GLFWwindow *w, double x, double y) {
+        screen->cursorPosCallbackEvent(x, y);
+    }
+    );
+
+    glfwSetMouseButtonCallback(window,
+        [](GLFWwindow *w, int button, int action, int modifiers) {
+        screen->mouseButtonCallbackEvent(button, action, modifiers);
+    }
+    );
+
+    glfwSetKeyCallback(window,
+        [](GLFWwindow *w, int key, int scancode, int action, int mods) {
+        screen->keyCallbackEvent(key, scancode, action, mods);
+    }
+    );
+
+    glfwSetCharCallback(window,
+        [](GLFWwindow *w, unsigned int codepoint) {
+        screen->charCallbackEvent(codepoint);
+    }
+    );
+
+    glfwSetDropCallback(window,
+        [](GLFWwindow *w, int count, const char **filenames) {
+        screen->dropCallbackEvent(count, filenames);
+    }
+    );
+
+    glfwSetScrollCallback(window,
+        [](GLFWwindow *w, double x, double y) {
+        screen->scrollCallbackEvent(x, y);
+    }
+    );
+
+    glfwSetFramebufferSizeCallback(window,
+        [](GLFWwindow* w, int width, int height) {
+        screen->resizeCallbackEvent(width, height);
+    }
+    );
+
+    // Game loop
+    while (!glfwWindowShouldClose(window)) {
+        // Check if any events have been activated (key pressed, mouse moved etc.) and call corresponding response functions
+        glfwPollEvents();
+
+        glClearColor(0.2f, 0.25f, 0.3f, 1.0f);
+        glClear(GL_COLOR_BUFFER_BIT);
+
+        // Draw nanogui
+        screen->drawContents();
+        screen->drawWidgets();
+
+        glfwSwapBuffers(window);
+    }
+
+    // Terminate GLFW, clearing any resources allocated by GLFW.
+    glfwTerminate();
+
+    return 0;
+}

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -377,20 +377,27 @@ void Screen::drawWidgets() {
             float bounds[4];
             nvgFontFace(mNVGContext, "sans");
             nvgFontSize(mNVGContext, 15.0f);
-            nvgTextAlign(mNVGContext, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+            nvgTextAlign(mNVGContext, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
             nvgTextLineHeight(mNVGContext, 1.1f);
             Vector2i pos = widget->absolutePosition() +
                            Vector2i(widget->width() / 2, widget->height() + 10);
 
-            nvgTextBoxBounds(mNVGContext, pos.x(), pos.y(), tooltipWidth,
+			nvgTextBounds(mNVGContext, pos.x(), pos.y(),
                              widget->tooltip().c_str(), nullptr, bounds);
+			int h = (bounds[2] - bounds[0]) / 2;
+			if (h > tooltipWidth / 2)
+			{
+				nvgTextAlign(mNVGContext, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+				nvgTextBoxBounds(mNVGContext, pos.x(), pos.y(), tooltipWidth,
+					widget->tooltip().c_str(), nullptr, bounds);
 
+				h = (bounds[2] - bounds[0]) / 2;
+			}
             nvgGlobalAlpha(mNVGContext,
                            std::min(1.0, 2 * (elapsed - 0.5f)) * 0.8);
 
             nvgBeginPath(mNVGContext);
             nvgFillColor(mNVGContext, Color(0, 255));
-            int h = (bounds[2] - bounds[0]) / 2;
             nvgRoundedRect(mNVGContext, bounds[0] - 4 - h, bounds[1] - 4,
                            (int) (bounds[2] - bounds[0]) + 8,
                            (int) (bounds[3] - bounds[1]) + 8, 3);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -391,7 +391,7 @@ void Screen::drawWidgets() {
 			{
 				nvgTextAlign(mNVGContext, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
 				nvgTextBoxBounds(mNVGContext, pos.x(), pos.y(), tooltipWidth,
-					widget->tooltip().c_str(), nullptr, bounds);
+                    widget->tooltip().c_str(), nullptr, bounds);
 
 				h = (bounds[2] - bounds[0]) / 2;
 			}

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -252,6 +252,15 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
         glfwSetWindowSize(window, mSize.x() * mPixelRatio, mSize.y() * mPixelRatio);
 #endif
 
+#if defined(NANOGUI_GLAD)
+    if (!gladInitialized) {
+        gladInitialized = true;
+        if (!gladLoadGLLoader((GLADloadproc)glfwGetProcAddress))
+            throw std::runtime_error("Could not initialize GLAD!");
+        glGetError(); // pull and ignore unhandled errors like GL_INVALID_ENUM
+    }
+#endif
+
     /* Detect framebuffer properties and set up compatible NanoVG context */
     GLint nStencilBits = 0, nSamples = 0;
     glGetFramebufferAttachmentParameteriv(GL_DRAW_FRAMEBUFFER,

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -387,8 +387,7 @@ void Screen::drawWidgets() {
             nvgTextBounds(mNVGContext, pos.x(), pos.y(),
                             widget->tooltip().c_str(), nullptr, bounds);
             int h = (bounds[2] - bounds[0]) / 2;
-            if (h > tooltipWidth / 2)
-            {
+            if (h > tooltipWidth / 2) {
                 nvgTextAlign(mNVGContext, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
                 nvgTextBoxBounds(mNVGContext, pos.x(), pos.y(), tooltipWidth,
                                 widget->tooltip().c_str(), nullptr, bounds);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -309,12 +309,12 @@ void Screen::setVisible(bool visible) {
     if (mVisible != visible) {
         mVisible = visible;
 
-		if (mOwningGLFWContext) {
-			if (visible)
-				glfwShowWindow(mGLFWWindow);
-			else
-				glfwHideWindow(mGLFWWindow);
-		}
+        if (mOwningGLFWContext) {
+            if (visible)
+                glfwShowWindow(mGLFWWindow);
+            else
+                glfwHideWindow(mGLFWWindow);
+        }
     }
 }
 
@@ -384,17 +384,17 @@ void Screen::drawWidgets() {
             Vector2i pos = widget->absolutePosition() +
                            Vector2i(widget->width() / 2, widget->height() + 10);
 
-			nvgTextBounds(mNVGContext, pos.x(), pos.y(),
-                             widget->tooltip().c_str(), nullptr, bounds);
-			int h = (bounds[2] - bounds[0]) / 2;
-			if (h > tooltipWidth / 2)
-			{
-				nvgTextAlign(mNVGContext, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
-				nvgTextBoxBounds(mNVGContext, pos.x(), pos.y(), tooltipWidth,
-                    widget->tooltip().c_str(), nullptr, bounds);
+            nvgTextBounds(mNVGContext, pos.x(), pos.y(),
+                            widget->tooltip().c_str(), nullptr, bounds);
+            int h = (bounds[2] - bounds[0]) / 2;
+            if (h > tooltipWidth / 2)
+            {
+                nvgTextAlign(mNVGContext, NVG_ALIGN_CENTER | NVG_ALIGN_TOP);
+                nvgTextBoxBounds(mNVGContext, pos.x(), pos.y(), tooltipWidth,
+                                widget->tooltip().c_str(), nullptr, bounds);
 
-				h = (bounds[2] - bounds[0]) / 2;
-			}
+                h = (bounds[2] - bounds[0]) / 2;
+            }
             nvgGlobalAlpha(mNVGContext,
                            std::min(1.0, 2 * (elapsed - 0.5f)) * 0.8);
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -73,7 +73,7 @@ static float get_pixel_ratio(GLFWwindow *window) {
 Screen::Screen()
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
       mCursor(Cursor::Arrow), mBackground(0.3f, 0.3f, 0.32f),
-      mShutdownGLFWOnDestruct(false), mFullscreen(false) {
+      mShutdownGLFWOnDestruct(false), mFullscreen(false), mOwningGLFWContext(false) {
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
 }
 
@@ -83,7 +83,7 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
                unsigned int glMajor, unsigned int glMinor)
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
       mCursor(Cursor::Arrow), mBackground(0.3f, 0.3f, 0.32f), mCaption(caption),
-      mShutdownGLFWOnDestruct(false), mFullscreen(fullscreen) {
+      mShutdownGLFWOnDestruct(false), mFullscreen(fullscreen), mOwningGLFWContext(true) {
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
 
     /* Request a forward compatible OpenGL glMajor.glMinor core profile context.
@@ -309,10 +309,12 @@ void Screen::setVisible(bool visible) {
     if (mVisible != visible) {
         mVisible = visible;
 
-        if (visible)
-            glfwShowWindow(mGLFWWindow);
-        else
-            glfwHideWindow(mGLFWWindow);
+		if (mOwningGLFWContext) {
+			if (visible)
+				glfwShowWindow(mGLFWWindow);
+			else
+				glfwHideWindow(mGLFWWindow);
+		}
     }
 }
 


### PR DESCRIPTION
Also include a new example, example3.cpp that demonstrates a way to create your own windows management code with glfw but still create GUI objects with nanogui.