### PR TITLE
fixed Screen::setSize high-DPI behaviour on windows

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -328,7 +328,12 @@ void Screen::setCaption(const std::string &caption) {
 
 void Screen::setSize(const Vector2i &size) {
     Widget::setSize(size);
+
+#if defined(_WIN32)
+    glfwSetWindowSize(mGLFWWindow, size.x() * mPixelRatio, size.y() * mPixelRatio);
+#else
     glfwSetWindowSize(mGLFWWindow, size.x(), size.y());
+#endif
 }
 
 void Screen::drawAll() {


### PR DESCRIPTION
Previously, calling setSize() on a high-DPI display would lead to the window being too small.

Unresolved: should setSize() do nothing if mFullscreen is true?