### PR TITLE
fixed window size when minimising on windows

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -369,7 +369,8 @@ void Screen::drawWidgets() {
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
 
     /* Calculate pixel ratio for hi-dpi devices. */
-    mPixelRatio = (float) mFBSize[0] / (float) mSize[0];
+    if (mSize[0])
+        mPixelRatio = (float) mFBSize[0] / (float) mSize[0];
     nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
 
     draw(mNVGContext);


### PR DESCRIPTION
When the window is minimised, glfwGetWindowSize() returns {0, 0} for the size on Windows, since it uses GetClientRect() internally. This leads to a division by zero when calculating mPixelRatio, which later triggers the window size to be updated in Screen::drawWidgets():
```
#if defined(_WIN32)
    if (mPixelRatio != newPixelRatio && !mFullscreen)
        glfwSetWindowSize(mGLFWWindow, mSize.x() * newPixelRatio / mPixelRatio, mSize.y() * newPixelRatio / mPixelRatio);
#endif
```

Fixes #95