### PR TITLE
Added margin initialization with default parameter to AdvancedGridLayout constructor(no tabs)

### DIFF
--- a/include/nanogui/layout.h
+++ b/include/nanogui/layout.h
@@ -248,7 +248,7 @@ public:
         }
     };
 
-    AdvancedGridLayout(const std::vector<int> &cols = {}, const std::vector<int> &rows = {});
+    AdvancedGridLayout(const std::vector<int> &cols = {}, const std::vector<int> &rows = {}, int margin = 0);
 
     int margin() const { return mMargin; }
     void setMargin(int margin) { mMargin = margin; }

--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -341,8 +341,8 @@ void GridLayout::performLayout(NVGcontext *ctx, Widget *widget) const {
     }
 }
 
-AdvancedGridLayout::AdvancedGridLayout(const std::vector<int> &cols, const std::vector<int> &rows)
- : mCols(cols), mRows(rows) {
+AdvancedGridLayout::AdvancedGridLayout(const std::vector<int> &cols, const std::vector<int> &rows, int margin)
+ : mCols(cols), mRows(rows), mMargin(margin) {
     mColStretch.resize(mCols.size(), 0);
     mRowStretch.resize(mRows.size(), 0);
 }


### PR DESCRIPTION
mMargin value was not initialized anywhere in AdvancedGridLayout. 
Added default margin parameter to AdvancedGridLayout constructor with 0 value like in GridLayout.
If user didn't call setMargin(value) explicitly after AdvancedGridLayout creation, mMargin had undefined value and because of it, positions of widgets computed by performLayout were very wrong.
//version without tabs.