### PR TITLE
Adding option to popup to appear at right or left side

### DIFF
--- a/include/nanogui/popup.h
+++ b/include/nanogui/popup.h
@@ -16,6 +16,10 @@
 
 NAMESPACE_BEGIN(nanogui)
 
+enum class PopupSide{
+    LEFTSIDE=0, RIGHTSIDE
+};
+
 /**
  * \brief Popup window for combo boxes, popup buttons, nested dialogs etc.
  *
@@ -36,6 +40,11 @@ public:
     void setAnchorHeight(int anchorHeight) { mAnchorHeight = anchorHeight; }
     /// Return the anchor height; this determines the vertical shift relative to the anchor position
     int anchorHeight() const { return mAnchorHeight; }
+
+    /// Set the popup side; this determines at what side of the parent window popup will appear
+    void setPopupSide(PopupSide popupSide) { mPopupSide = popupSide; }
+    /// Return the popup side; this determines at what side of the parent window popup will appear
+    PopupSide popupSide() const { return mPopupSide; }
 
     /// Return the parent window of the popup
     Window *parentWindow() { return mParentWindow; }
@@ -58,6 +67,7 @@ protected:
     Window *mParentWindow;
     Vector2i mAnchorPos;
     int mAnchorHeight;
+    PopupSide mPopupSide;
 };
 
 NAMESPACE_END(nanogui)

--- a/include/nanogui/popupbutton.h
+++ b/include/nanogui/popupbutton.h
@@ -26,6 +26,9 @@ public:
     void setChevronIcon(int icon) { mChevronIcon = icon; }
     int chevronIcon() const { return mChevronIcon; }
 
+    void setPopupSide(PopupSide popupSide);
+    PopupSide popupSide() const { return mPopup->popupSide(); }
+
     Popup *popup() { return mPopup; }
     const Popup *popup() const { return mPopup; }
 

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -19,7 +19,7 @@ NAMESPACE_BEGIN(nanogui)
     
 Popup::Popup(Widget *parent, Window *parentWindow)
     : Window(parent, ""), mParentWindow(parentWindow),
-      mAnchorPos(Vector2i::Zero()), mAnchorHeight(30) {
+      mAnchorPos(Vector2i::Zero()), mAnchorHeight(30), mPopupSide(PopupSide::RIGHTSIDE) {
 }
 
 void Popup::performLayout(NVGcontext *ctx) {
@@ -29,6 +29,9 @@ void Popup::performLayout(NVGcontext *ctx) {
         mChildren[0]->setPosition(Vector2i::Zero());
         mChildren[0]->setSize(mSize);
         mChildren[0]->performLayout(ctx);
+    }
+    if(mPopupSide == PopupSide::LEFTSIDE){
+        mAnchorPos[0] -= size()[0];
     }
 }
 
@@ -62,9 +65,15 @@ void Popup::draw(NVGcontext* ctx) {
     nvgBeginPath(ctx);
     nvgRoundedRect(ctx, mPos.x(), mPos.y(), mSize.x(), mSize.y(), cr);
 
-    nvgMoveTo(ctx, mPos.x()-15,mPos.y()+mAnchorHeight);
-    nvgLineTo(ctx, mPos.x()+1,mPos.y()+mAnchorHeight-15);
-    nvgLineTo(ctx, mPos.x()+1,mPos.y()+mAnchorHeight+15);
+    if(mPopupSide == PopupSide::RIGHTSIDE){
+        nvgMoveTo(ctx, mPos.x()-15,mPos.y()+mAnchorHeight);
+        nvgLineTo(ctx, mPos.x()+1,mPos.y()+mAnchorHeight-15);
+        nvgLineTo(ctx, mPos.x()+1,mPos.y()+mAnchorHeight+15);
+    }else{
+        nvgMoveTo(ctx, mPos.x()+mSize.x()+15,mPos.y()+mAnchorHeight);
+        nvgLineTo(ctx, mPos.x()+mSize.x()-1,mPos.y()+mAnchorHeight-15);
+        nvgLineTo(ctx, mPos.x()+mSize.x()-1,mPos.y()+mAnchorHeight+15);
+    }
 
     nvgFillColor(ctx, mTheme->mWindowPopup);
     nvgFill(ctx);
@@ -76,12 +85,16 @@ void Popup::save(Serializer &s) const {
     Window::save(s);
     s.set("anchorPos", mAnchorPos);
     s.set("anchorHeight", mAnchorHeight);
+    s.set("popupSide", (int)mPopupSide);
 }
 
 bool Popup::load(Serializer &s) {
     if (!Window::load(s)) return false;
     if (!s.get("anchorPos", mAnchorPos)) return false;
     if (!s.get("anchorHeight", mAnchorHeight)) return false;
+    int dummy;
+    if (!s.get("popupSide", dummy)) return false;
+    mPopupSide = (PopupSide)dummy;
     return true;
 }
 

--- a/src/popupbutton.cpp
+++ b/src/popupbutton.cpp
@@ -51,8 +51,12 @@ void PopupButton::draw(NVGcontext* ctx) {
         nvgTextAlign(ctx, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
 
         float iw = nvgTextBounds(ctx, 0, 0, icon.data(), nullptr, nullptr);
-        Vector2f iconPos(mPos.x() + mSize.x() - iw - 8,
-                         mPos.y() + mSize.y() * 0.5f - 1);
+        Vector2f iconPos(0, mPos.y() + mSize.y() * 0.5f - 1);
+        if(mPopup->popupSide() == PopupSide::RIGHTSIDE){
+            iconPos[0] = mPos.x() + mSize.x() - iw - 8;
+        }else{
+            iconPos[0] = mPos.x() + 8;
+        }
 
         nvgText(ctx, iconPos.x(), iconPos.y(), icon.data(), nullptr);
     }
@@ -63,8 +67,21 @@ void PopupButton::performLayout(NVGcontext *ctx) {
 
     const Window *parentWindow = window();
 
-    mPopup->setAnchorPos(Vector2i(parentWindow->width() + 15,
-        absolutePosition().y() - parentWindow->position().y() + mSize.y() /2));
+    int posY = absolutePosition().y() - parentWindow->position().y() + mSize.y() /2;
+    if(mPopup->popupSide() == PopupSide::RIGHTSIDE){
+        mPopup->setAnchorPos(Vector2i(parentWindow->width() + 15, posY));
+    }else{
+        mPopup->setAnchorPos(Vector2i(0 - 15, posY));
+    }
+}
+
+void PopupButton::setPopupSide(PopupSide popupSide) {
+    if(mPopup->popupSide() == PopupSide::RIGHTSIDE && mChevronIcon == ENTYPO_ICON_CHEVRON_SMALL_RIGHT){
+        setChevronIcon(ENTYPO_ICON_CHEVRON_SMALL_LEFT);
+    }else if(mPopup->popupSide() == PopupSide::LEFTSIDE && mChevronIcon == ENTYPO_ICON_CHEVRON_SMALL_LEFT){
+        setChevronIcon(ENTYPO_ICON_CHEVRON_SMALL_RIGHT);
+    }
+    mPopup->setPopupSide(popupSide);
 }
 
 void PopupButton::save(Serializer &s) const {


### PR DESCRIPTION
It looks like this: http://imgur.com/xc49tzo
and to use it you need to call `popupBtn->setPopupSide(PopupSide::LEFTSIDE);` after popupButton creation.
Not sure about save/load changes, can I save it as enum or need to convert to int like I'm doing?
And if a user calls setPopupSide on popup window instead of a button, then mChevronIcon will not be set to opposite side value.