### PR TITLE
Fixed crashing if no text is pasted in a textbox

### DIFF
--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -520,8 +520,7 @@ void TextBox::pasteFromClipboard() {
     Screen *sc = dynamic_cast<Screen *>(this->window()->parent());
     const char* cbstr = glfwGetClipboardString(sc->glfwWindow());
     if (cbstr){
-        std::string str(cbstr);
-        mValueTemp.insert(mCursorPos, str);
+        mValueTemp.insert(mCursorPos, std::string(cbstr));
     }
 }
 

--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -518,8 +518,11 @@ bool TextBox::copySelection() {
 
 void TextBox::pasteFromClipboard() {
     Screen *sc = dynamic_cast<Screen *>(this->window()->parent());
-    std::string str(glfwGetClipboardString(sc->glfwWindow()));
-    mValueTemp.insert(mCursorPos, str);
+    const char* cbstr = glfwGetClipboardString(sc->glfwWindow());
+    if (cbstr){
+        std::string str(cbstr);
+        mValueTemp.insert(mCursorPos, str);
+    }
 }
 
 bool TextBox::deleteSelection() {


### PR DESCRIPTION
More specifically, if non-text is pasted into a textbox, an exception is thrown.

ie. pasting a file, or an image