### PR TITLE
Fixed crashing if no text is pasted in a textbox

### DIFF
--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -518,8 +518,10 @@ bool TextBox::copySelection() {
 
 void TextBox::pasteFromClipboard() {
     Screen *sc = dynamic_cast<Screen *>(this->window()->parent());
-    std::string str(glfwGetClipboardString(sc->glfwWindow()));
-    mValueTemp.insert(mCursorPos, str);
+    const char* cbstr = glfwGetClipboardString(sc->glfwWindow());
+    if (cbstr){
+        mValueTemp.insert(mCursorPos, std::string(cbstr));
+    }
 }
 
 bool TextBox::deleteSelection() {


### PR DESCRIPTION
More specifically, if non-text is pasted into a textbox, an exception is thrown.

ie. pasting a file, or an image