### PR TITLE
Adding minimize window method to the window widget

### DIFF
--- a/include/nanogui/window.h
+++ b/include/nanogui/window.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include <nanogui/widget.h>
+#include <unordered_map>
 
 NAMESPACE_BEGIN(nanogui)
 
@@ -29,6 +30,13 @@ public:
     bool modal() const { return mModal; }
     /// Set whether or not this is a modal dialog
     void setModal(bool modal) { mModal = modal; }
+
+    /// Is this window minimized
+    bool minimized() const { return mMinimized; }
+    /// Set minimized state
+    void setMinimized(bool minimized);
+    /// Toggle minimize - minimize or expand window depending on the current minimized state
+    void toggleMinimized(){ setMinimized(!mMinimized); }
 
     /// Return the panel used to house window buttons
     Widget *buttonPanel();
@@ -56,11 +64,21 @@ public:
 protected:
     /// Internal helper function to maintain nested window position values; overridden in \ref Popup
     virtual void refreshRelativePlacement();
+
+    /// Internal helper function to restore mChildren visible states from mChildrenVisibleStates
+    void restoreChildrenVisibleStates();
+    /// Internal helper function to save mChildren visible states to mChildrenVisibleStates
+    void saveChildrenVisibleStates();
+    /// Internal helper function to set visible false for all mChildren
+    void hideAllChildren(bool hideButtonPanel=false);
 protected:
     std::string mTitle;
     Widget *mButtonPanel;
     bool mModal;
     bool mDrag;
+    bool mMinimized;
+    Vector2i mNotMinimizedSize;
+    std::unordered_map<Widget *, bool> mChildrenVisibleStates;
 };
 
 NAMESPACE_END(nanogui)


### PR DESCRIPTION
How to use:
```
window->toggleMinimized();
window->setMinimized(true/false);
```

When minimized window looks like a window without content with height of a header that contains title or button panel or 0 if title is empty and button panel doesn't exist or not visible.

On minimize I'm saving visible state for each widget in mChildren inside unordered_map and hide all children with setVisible(false) except button panel(optional). I also store current size before minimization. I set size to current width and mTheme->mWindowHeaderHeight

On setMinimize(false) I'm restoring saved size and for each widget I'm restoring its visible state except those that were set to be true while being minimized or new widgets.

Convenient use case:
```
        Button* btn = window->buttonPanel()->add<Button>("", ENTYPO_ICON_CHEVRON_SMALL_UP);
        btn->setCallback([window, btn](){
            window->toggleMinimized();
            if(window->minimized()){
                btn->setIcon(ENTYPO_ICON_CHEVRON_SMALL_DOWN);
            }else{
                btn->setIcon(ENTYPO_ICON_CHEVRON_SMALL_UP); 
            }
        });
```

Not sure about method names, variable names and whether I should include something into save/load methods.