### PR TITLE
Fixing invisible widget is not registered with AdvancedGridLayout error

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -380,9 +380,9 @@ void AdvancedGridLayout::performLayout(NVGcontext *ctx, Widget *widget) const {
             grid[axis][i] += grid[axis][i-1];
 
         for (Widget *w : widget->children()) {
-            Anchor anchor = this->anchor(w);
             if (!w->visible())
                 continue;
+            Anchor anchor = this->anchor(w);
 
             int itemPos = grid[axis][anchor.pos[axis]];
             int cellSize  = grid[axis][anchor.pos[axis] + anchor.size[axis]] - itemPos;


### PR DESCRIPTION
All other layouts check for invisibility right away and continue processing only if a widget is visible. AdvancedGridLayout was calling anchor before check for no apparent reason(for me at least). It was breaking addition of buttonPanel in a window with AdvancedGridLayout.(throw std::runtime_error("Widget was not registered with the grid layout!");) Button panel is not supposed to be registered with layout and because of this I think it's set to not visible before performeLayout on a window is called.

How to reproduce - in example2.cpp
add this after helper window creation and try to run.
`window->buttonPanel()->add<Button>("X");`
