### PR TITLE
Fix: Example3 calls glViewport too early.

### DIFF
--- a/src/example3.cpp
+++ b/src/example3.cpp
@@ -81,7 +81,7 @@ int main(int /* argc */, char ** /* argv */) {
 
     int width, height;
     glfwGetFramebufferSize(window, &width, &height);
-    glViewport(0, 0, width, height);
+
     glfwSwapInterval(0);
     glfwSwapBuffers(window);
 

--- a/src/example3.cpp
+++ b/src/example3.cpp
@@ -79,15 +79,15 @@ int main(int /* argc */, char ** /* argv */) {
     }
     glfwMakeContextCurrent(window);
 
-    int width, height;
-    glfwGetFramebufferSize(window, &width, &height);
-
-    glfwSwapInterval(0);
-    glfwSwapBuffers(window);
-
     // Create a nanogui screen and pass the glfw pointer to initialize
     screen = new Screen();
     screen->initialize(window, true);
+
+    // Clear screen
+    glfwSwapInterval(0);
+    glClearColor(0, 0, 0, 1);
+    glClear(GL_COLOR_BUFFER_BIT);
+    glfwSwapBuffers(window);
 
     // Create nanogui gui
     bool enabled = true;


### PR DESCRIPTION
In example3, glViewport was called before initializing GLAD, causing the example to crash on Windows. Just removing the glViewport call seems to work fine.