### PR TITLE
Aux drawing function

### DIFF
--- a/include/nanogui/popup.h
+++ b/include/nanogui/popup.h
@@ -53,6 +53,7 @@ public:
 
     virtual void save(Serializer &s) const override;
     virtual bool load(Serializer &s) override;
+    virtual bool drawsFirst() const override { return true; }
 protected:
     /// Internal helper function to maintain nested window position values
     virtual void refreshRelativePlacement() override;

--- a/include/nanogui/tabwidget.h
+++ b/include/nanogui/tabwidget.h
@@ -90,6 +90,7 @@ public:
     virtual void performLayout(NVGcontext* ctx) override;
     virtual Vector2i preferredSize(NVGcontext* ctx) const override;
     virtual void draw(NVGcontext* ctx) override;
+    virtual bool drawsFirst() const override { return true; }
 
 private:
     TabHeader* mHeader;

--- a/include/nanogui/vscrollpanel.h
+++ b/include/nanogui/vscrollpanel.h
@@ -31,6 +31,7 @@ public:
     virtual Vector2i preferredSize(NVGcontext *ctx) const override;
     virtual bool mouseDragEvent(const Vector2i &p, const Vector2i &rel, int button, int modifiers) override;
     virtual bool scrollEvent(const Vector2i &p, const Vector2f &rel) override;
+    virtual void drawEx(NVGcontext *ctx) override;
     virtual void draw(NVGcontext *ctx) override;
     virtual void save(Serializer &s) const override;
     virtual bool load(Serializer &s) override;

--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -241,7 +241,9 @@ public:
 
     /// Restore the state of the widget from the given \ref Serializer instance
     virtual bool load(Serializer &s);
-
+    
+    virtual bool drawsFirst() const { return false; }
+    
 protected:
     /// Free all resources used by the widget and any children
     virtual ~Widget();

--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -234,6 +234,7 @@ public:
     virtual void performLayout(NVGcontext *ctx);
 
     /// Draw the widget (and all child widgets)
+    virtual void drawEx(NVGcontext *ctx);
     virtual void draw(NVGcontext *ctx);
 
     /// Save the state of the widget into the given \ref Serializer instance

--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -242,10 +242,10 @@ public:
 
     /// Restore the state of the widget from the given \ref Serializer instance
     virtual bool load(Serializer &s);
-    
+
     /// Per default, signify that this instance draws after its children
     virtual bool drawsFirst() const { return false; }
-    
+
 protected:
     /// Free all resources used by the widget and any children
     virtual ~Widget();

--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -233,7 +233,7 @@ public:
     /// Invoke the associated layout generator to properly place child widgets, if any
     virtual void performLayout(NVGcontext *ctx);
 
-    /// Draw the widget (and all child widgets)
+    /// Draw the widget (and all child widgets); drawEx() is a helper function
     virtual void drawEx(NVGcontext *ctx);
     virtual void draw(NVGcontext *ctx);
 
@@ -243,6 +243,7 @@ public:
     /// Restore the state of the widget from the given \ref Serializer instance
     virtual bool load(Serializer &s);
     
+    /// Per default, signify that this instance draws after its children
     virtual bool drawsFirst() const { return false; }
     
 protected:

--- a/include/nanogui/window.h
+++ b/include/nanogui/window.h
@@ -59,6 +59,8 @@ public:
     virtual void performLayout(NVGcontext *ctx) override;
     virtual void save(Serializer &s) const override;
     virtual bool load(Serializer &s) override;
+
+    /// Signify that this instance draws before its children
     virtual bool drawsFirst() const override { return true; }
     
 protected:

--- a/include/nanogui/window.h
+++ b/include/nanogui/window.h
@@ -59,6 +59,8 @@ public:
     virtual void performLayout(NVGcontext *ctx) override;
     virtual void save(Serializer &s) const override;
     virtual bool load(Serializer &s) override;
+    virtual bool drawsFirst() const override { return true; }
+    
 protected:
     /// Internal helper function to maintain nested window position values; overridden in \ref Popup
     virtual void refreshRelativePlacement();

--- a/include/nanogui/window.h
+++ b/include/nanogui/window.h
@@ -62,7 +62,7 @@ public:
 
     /// Signify that this instance draws before its children
     virtual bool drawsFirst() const override { return true; }
-    
+
 protected:
     /// Internal helper function to maintain nested window position values; overridden in \ref Popup
     virtual void refreshRelativePlacement();

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -104,8 +104,6 @@ bool Button::mouseButtonEvent(const Vector2i &p, int button, bool down, int modi
 }
 
 void Button::draw(NVGcontext *ctx) {
-    Widget::draw(ctx);
-
     NVGcolor gradTop = mTheme->mButtonGradientTopUnfocused;
     NVGcolor gradBot = mTheme->mButtonGradientBotUnfocused;
 

--- a/src/checkbox.cpp
+++ b/src/checkbox.cpp
@@ -56,8 +56,6 @@ Vector2i CheckBox::preferredSize(NVGcontext *ctx) const {
 }
 
 void CheckBox::draw(NVGcontext *ctx) {
-    Widget::draw(ctx);
-
     nvgFontSize(ctx, fontSize());
     nvgFontFace(ctx, "sans");
     nvgFillColor(ctx,

--- a/src/colorwheel.cpp
+++ b/src/colorwheel.cpp
@@ -30,8 +30,6 @@ Vector2i ColorWheel::preferredSize(NVGcontext *) const {
 }
 
 void ColorWheel::draw(NVGcontext *ctx) {
-    Widget::draw(ctx);
-
     if (!mVisible)
         return;
 

--- a/src/graph.cpp
+++ b/src/graph.cpp
@@ -28,8 +28,6 @@ Vector2i Graph::preferredSize(NVGcontext *) const {
 }
 
 void Graph::draw(NVGcontext *ctx) {
-    Widget::draw(ctx);
-
     nvgBeginPath(ctx);
     nvgRect(ctx, mPos.x(), mPos.y(), mSize.x(), mSize.y());
     nvgFillColor(ctx, mBackgroundColor);

--- a/src/imageview.cpp
+++ b/src/imageview.cpp
@@ -280,7 +280,6 @@ void ImageView::performLayout(NVGcontext* ctx) {
 }
 
 void ImageView::draw(NVGcontext* ctx) {
-    Widget::draw(ctx);
     nvgEndFrame(ctx); // Flush the NanoVG draw stack, not necessary to call nvgBeginFrame afterwards.
 
     drawWidgetBorder(ctx);

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -55,7 +55,6 @@ Vector2i Label::preferredSize(NVGcontext *ctx) const {
 }
 
 void Label::draw(NVGcontext *ctx) {
-    Widget::draw(ctx);
     nvgFontFace(ctx, mFont.c_str());
     nvgFontSize(ctx, fontSize());
     nvgFillColor(ctx, mColor);

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -68,8 +68,6 @@ void Popup::draw(NVGcontext* ctx) {
 
     nvgFillColor(ctx, mTheme->mWindowPopup);
     nvgFill(ctx);
-
-    Widget::draw(ctx);
 }
 
 void Popup::save(Serializer &s) const {

--- a/src/progressbar.cpp
+++ b/src/progressbar.cpp
@@ -23,8 +23,6 @@ Vector2i ProgressBar::preferredSize(NVGcontext *) const {
 }
 
 void ProgressBar::draw(NVGcontext* ctx) {
-    Widget::draw(ctx);
-
     NVGpaint paint = nvgBoxGradient(
         ctx, mPos.x() + 1, mPos.y() + 1,
         mSize.x()-2, mSize.y(), 3, 4, Color(0, 32), Color(0, 92));

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -384,7 +384,7 @@ void Screen::drawWidgets() {
     glBindSampler(0, 0);
     nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
 
-    draw(mNVGContext);
+    drawEx(mNVGContext);
 
     double elapsed = glfwGetTime() - mLastInteraction;
 

--- a/src/tabheader.cpp
+++ b/src/tabheader.cpp
@@ -353,7 +353,6 @@ bool TabHeader::mouseButtonEvent(const Vector2i &p, int button, bool down, int m
 
 void TabHeader::draw(NVGcontext* ctx) {
     // Draw controls.
-    Widget::draw(ctx);
     if (mOverflowing)
         drawControls(ctx);
 

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -165,8 +165,6 @@ void TabWidget::draw(NVGcontext* ctx) {
         nvgStroke(ctx);
         nvgRestore(ctx);
     }
-
-    Widget::draw(ctx);
 }
 
 NAMESPACE_END(nanogui)

--- a/src/textbox.cpp
+++ b/src/textbox.cpp
@@ -82,8 +82,6 @@ Vector2i TextBox::preferredSize(NVGcontext *ctx) const {
 }
 
 void TextBox::draw(NVGcontext* ctx) {
-    Widget::draw(ctx);
-
     NVGpaint bg = nvgBoxGradient(ctx,
         mPos.x() + 1, mPos.y() + 1 + 1.0f, mSize.x() - 2, mSize.y() - 2,
         3, 4, Color(255, 32), Color(32, 32));

--- a/src/vscrollpanel.cpp
+++ b/src/vscrollpanel.cpp
@@ -78,6 +78,10 @@ bool VScrollPanel::scrollEvent(const Vector2i &p, const Vector2f &rel) {
     }
 }
 
+void VScrollPanel::drawEx(NVGcontext *ctx) {
+  this->draw(ctx);
+}
+
 void VScrollPanel::draw(NVGcontext *ctx) {
     if (mChildren.empty())
         return;
@@ -94,7 +98,7 @@ void VScrollPanel::draw(NVGcontext *ctx) {
     nvgTranslate(ctx, mPos.x(), mPos.y());
     nvgIntersectScissor(ctx, 0, 0, mSize.x(), mSize.y());
     if (child->visible())
-        child->draw(ctx);
+        child->drawEx(ctx);
     nvgRestore(ctx);
 
     if (mChildPreferredHeight <= mSize.y())

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -194,7 +194,7 @@ void Widget::drawEx(NVGcontext *ctx) {
         this->draw(ctx);
         this->Widget::draw(ctx);
     }
-    
+
     if (!mChildren.empty()) {
         nvgTranslate(ctx, mPos.x(), mPos.y());
         for (auto child : mChildren)
@@ -202,7 +202,7 @@ void Widget::drawEx(NVGcontext *ctx) {
                 child->drawEx(ctx);
         nvgTranslate(ctx, -mPos.x(), -mPos.y());
     }
-    
+
     if (!this->drawsFirst()) {
         this->draw(ctx);
         this->Widget::draw(ctx);

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -189,6 +189,22 @@ void Widget::requestFocus() {
     ((Screen *) widget)->updateFocus(this);
 }
 
+void Widget::drawEx(NVGcontext *ctx) {
+    if (this->drawsFirst())
+        this->draw(ctx);
+    
+    if (!mChildren.empty()) {
+        nvgTranslate(ctx, mPos.x(), mPos.y());
+        for (auto child : mChildren)
+            if (child->visible())
+                child->drawEx(ctx);
+        nvgTranslate(ctx, -mPos.x(), -mPos.y());
+    }
+    
+    if (!this->drawsFirst())
+        this->draw(ctx);
+}
+
 void Widget::draw(NVGcontext *ctx) {
     #if NANOGUI_SHOW_WIDGET_BOUNDS
         nvgStrokeWidth(ctx, 1.0f);
@@ -197,15 +213,6 @@ void Widget::draw(NVGcontext *ctx) {
         nvgStrokeColor(ctx, nvgRGBA(255, 0, 0, 255));
         nvgStroke(ctx);
     #endif
-
-    if (mChildren.empty())
-        return;
-
-    nvgTranslate(ctx, mPos.x(), mPos.y());
-    for (auto child : mChildren)
-        if (child->visible())
-            child->draw(ctx);
-    nvgTranslate(ctx, -mPos.x(), -mPos.y());
 }
 
 void Widget::save(Serializer &s) const {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -192,7 +192,7 @@ void Widget::requestFocus() {
 void Widget::drawEx(NVGcontext *ctx) {
     if (this->drawsFirst()) {
         this->draw(ctx);
-	this->Widget::draw(ctx);
+        this->Widget::draw(ctx);
     }
     
     if (!mChildren.empty()) {
@@ -205,7 +205,7 @@ void Widget::drawEx(NVGcontext *ctx) {
     
     if (!this->drawsFirst()) {
         this->draw(ctx);
-	this->Widget::draw(ctx);
+        this->Widget::draw(ctx);
     }
 }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -190,8 +190,10 @@ void Widget::requestFocus() {
 }
 
 void Widget::drawEx(NVGcontext *ctx) {
-    if (this->drawsFirst())
+    if (this->drawsFirst()) {
         this->draw(ctx);
+	this->Widget::draw(ctx);
+    }
     
     if (!mChildren.empty()) {
         nvgTranslate(ctx, mPos.x(), mPos.y());
@@ -201,8 +203,10 @@ void Widget::drawEx(NVGcontext *ctx) {
         nvgTranslate(ctx, -mPos.x(), -mPos.y());
     }
     
-    if (!this->drawsFirst())
+    if (!this->drawsFirst()) {
         this->draw(ctx);
+	this->Widget::draw(ctx);
+    }
 }
 
 void Widget::draw(NVGcontext *ctx) {

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -135,7 +135,6 @@ void Window::draw(NVGcontext *ctx) {
     }
 
     nvgRestore(ctx);
-    Widget::draw(ctx);
 }
 
 void Window::dispose() {


### PR DESCRIPTION
This removes the need to call `Widget::draw()` from `Widget` subclasses by adding an auxiliary drawing function that does the housekeeping for drawing.

I tried to adhere to your coding style as closely as possible.