### PR TITLE
`else()` and `endif()` upside down when deciding whether to build python plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,9 +398,9 @@ if (NANOGUI_BUILD_PYTHON)
     # Python not found -- disable the plugin
     set(NANOGUI_BUILD_PYTHON OFF CACHE BOOL "Build a Python plugin for NanoGUI?" FORCE)
     message(WARNING "NanoGUI: not building the Python plugin!")
-  endif()
-    message(STATUS "NanoGUI: building the Python plugin.")
   else()
+    message(STATUS "NanoGUI: building the Python plugin.")
+  endif()
 endif()
 
 if (NANOGUI_BUILD_PYTHON)


### PR DESCRIPTION
This just mixed up whether to display the "NanoGUI: building the Python plugin." message or not (it would always show), but still.