### PR TITLE
bin2c needs absolute path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ endforeach()
 # Run bin2c on resource files
 add_custom_command(
   OUTPUT nanogui_resources.cpp nanogui_resources.h
-  COMMAND bin2c ARGS ${bin2c_cmdline}
+  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/bin2c ARGS ${bin2c_cmdline}
   DEPENDS bin2c ${resources}
   COMMENT "Running bin2c"
   PRE_BUILD VERBATIM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,7 @@ endforeach()
 # Run bin2c on resource files
 add_custom_command(
   OUTPUT nanogui_resources.cpp nanogui_resources.h
-  COMMAND ${CMAKE_CURRENT_BINARY_DIR}/bin2c ARGS ${bin2c_cmdline}
+  COMMAND $<TARGET_FILE:bin2c> ARGS ${bin2c_cmdline}
   DEPENDS bin2c ${resources}
   COMMENT "Running bin2c"
   PRE_BUILD VERBATIM)


### PR DESCRIPTION
My environment( my be others ) has bin2c already. so I think the abolute path is needed for bin2c in CMakeLists.txt.

```
$ which bin2c
/usr/local/cuda-6.5/bin/bin2c
```