### PR TITLE
Scissor children

### DIFF
--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -209,7 +209,7 @@ void Widget::draw(NVGcontext *ctx) {
             nvgSave(ctx);
             child->draw(ctx);
             nvgRestore(ctx);
-	}
+        }
     nvgRestore(ctx);
 }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -201,11 +201,16 @@ void Widget::draw(NVGcontext *ctx) {
     if (mChildren.empty())
         return;
 
+    nvgSave(ctx);
     nvgTranslate(ctx, mPos.x(), mPos.y());
+    nvgScissor(ctx, 0, 0, mSize.x(), mSize.y());
     for (auto child : mChildren)
-        if (child->visible())
+        if (child->visible()) {
+            nvgSave(ctx);
             child->draw(ctx);
-    nvgTranslate(ctx, -mPos.x(), -mPos.y());
+            nvgRestore(ctx);
+	}
+    nvgRestore(ctx);
 }
 
 void Widget::save(Serializer &s) const {


### PR DESCRIPTION
When forcing a fixed size onto a widget, its child widgets can still draw outside of its designated area. Using the fix in this PR, the widget restricts that area using `nvgScissor` prior to drawing the children.

Example without/with the fix:

<img src="https://cloud.githubusercontent.com/assets/1122132/19771313/d30072fa-9c62-11e6-8cf1-708b0b2ba80e.png" height="130"/>&nbsp;<img src="https://cloud.githubusercontent.com/assets/1122132/19771318/d5071d92-9c62-11e6-8542-1fd69c8e2486.png" height="130"/>

This example forces a fixed height onto the window titled "Tools".