### PR TITLE
[docs] updating documentation system for python3

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -46,7 +46,7 @@ help:
 
 .PHONY: clean
 clean:
-	rm -rf $(BUILDDIR)/*
+	rm -rf $(BUILDDIR)/ doxyoutput/ generated_api/ __pycache__/ *.pyc
 
 .PHONY: html
 html:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -318,8 +318,8 @@ def generateDoxygenXML(stripPath):
     from subprocess import PIPE, Popen
     try:
         doxygen_cmd = ["doxygen", "-"]# "-" tells Doxygen to read configs from stdin
-        doxygen_proc = Popen(doxygen_cmd, stdin=PIPE)
-        doxygen_proc.communicate(input=r'''
+        doxygen_proc  = Popen(doxygen_cmd, stdin=PIPE)
+        doxygen_input = r'''
             # Make this the same as what you tell exhale.
             OUTPUT_DIRECTORY       = doxyoutput
             # If you need this to be YES, exhale will probably break.
@@ -354,7 +354,11 @@ def generateDoxygenXML(stripPath):
             PREDEFINED            += DOXYGEN_SHOULD_SKIP_THIS
             PREDEFINED            += DOXYGEN_DOCUMENTATION_BUILD
             PREDEFINED            += NANOGUI_EXPORT
-        ''' % stripPath)
+        ''' % stripPath
+        # In python 3 strings and bytes are no longer interchangeable
+        if sys.version[0] == "3":
+            doxygen_input = bytes(doxygen_input, 'ASCII')
+        doxygen_proc.communicate(input=doxygen_input)
         doxygen_proc.stdin.close()
         if doxygen_proc.wait() != 0:
             raise RuntimeError("Non-zero return code from 'doxygen'...")

--- a/docs/exhale.py
+++ b/docs/exhale.py
@@ -1,5 +1,9 @@
 # This file is part of exhale: https://github.com/svenevs/exhale
 #
+# This file was generated on/around (date -Ru):
+#
+#             Tue, 08 Nov 2016 07:18:48 +0000
+#
 # Copyright (c) 2016, Stephen McDowell
 # All rights reserved.
 #
@@ -32,8 +36,13 @@ from breathe.parser.index import parse as breathe_parse
 import sys
 import re
 import os
-import cStringIO
 import itertools
+try:
+    # Python 2 StringIO
+    from cStringIO import StringIO
+except ImportError:
+    # Python 3 StringIO
+    from io import StringIO
 
 __all__ = ['generate', 'ExhaleRoot', 'ExhaleNode', 'exclaimError', 'qualifyKind',
            'kindAsBreatheDirective', 'specificationsForKind', 'EXHALE_FILE_HEADING',
@@ -971,7 +980,7 @@ class ExhaleNode:
                 An integer greater than or equal to 0 representing the indentation level
                 for this node.
 
-            ``stream`` (cStringIO.StringIO)
+            ``stream`` (StringIO)
                 The stream that is being written to by all of the nodes (created and
                 destroyed by the ExhaleRoot object).
 
@@ -1118,7 +1127,7 @@ class ExhaleNode:
                 An integer greater than or equal to 0 representing the indentation level
                 for this node.
 
-            ``stream`` (cStringIO.StringIO)
+            ``stream`` (StringIO)
                 The stream that is being written to by all of the nodes (created and
                 destroyed by the ExhaleRoot object).
 
@@ -2243,7 +2252,7 @@ class ExhaleRoot:
                         # double nested and beyond to appear after their parent by
                         # sorting on their name
                         nested_children.sort(key=lambda x: x.name)
-                        nested_child_stream = cStringIO.StringIO()
+                        nested_child_stream = StringIO()
                         for nc in nested_children:
                             nested_child_stream.write("- :ref:`{}`\n".format(nc.link_name))
 
@@ -2670,7 +2679,7 @@ class ExhaleRoot:
                 Whether or not to use the collapsibleList version.  See the
                 ``createTreeView`` description in :func:`exhale.generate`.
         '''
-        class_view_stream = cStringIO.StringIO()
+        class_view_stream = StringIO()
 
         for n in self.namespaces:
             n.toClassView(0, class_view_stream, treeView)
@@ -2700,7 +2709,7 @@ class ExhaleRoot:
             # need to restart since there were no missing children found, otherwise the
             # last namespace will not correctly have a lastChild
             class_view_stream.close()
-            class_view_stream = cStringIO.StringIO()
+            class_view_stream = StringIO()
 
             last_nspace_index = len(self.namespaces) - 1
             for idx in range(last_nspace_index + 1):
@@ -2743,7 +2752,7 @@ class ExhaleRoot:
                 Whether or not to use the collapsibleList version.  See the
                 ``createTreeView`` description in :func:`exhale.generate`.
         '''
-        directory_view_stream = cStringIO.StringIO()
+        directory_view_stream = StringIO()
 
         for d in self.dirs:
             d.toDirectoryView(0, directory_view_stream, treeView)
@@ -2765,7 +2774,7 @@ class ExhaleRoot:
             # need to restart since there were no missing children found, otherwise the
             # last directory will not correctly have a lastChild
             directory_view_stream.close()
-            directory_view_stream = cStringIO.StringIO()
+            directory_view_stream = StringIO()
 
             last_dir_index = len(self.dirs) - 1
             for idx in range(last_dir_index + 1):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 breathe
+# git+git://github.com/michaeljones/breathe@v4.3.1#egg=breathe


### PR DESCRIPTION
This commit fixes some small oversights that prevented the documentation
from building with python3, remedying concerns in https://github.com/wjakob/nanogui/pull/160

This commit is tested and working here: fake-nanogui.rtfd.io

Further debugging of exhale has revealed why certain functions / typedefs / enums etc will
link to their defining file locally, but not on RTD.  Cause is clear, solution is not.
Will have to consult the folks at RTD to see if they have any input on how to get doxygen
to behave 'normally'.

Full summary:
- Adding better clean target to the Makefile
- Fixed generateDoxygenXML in conf.py
    - This was actually the problem all along, breathe was python3 compatible
- Update exhale to use StringIO correctly for python 2 and 3
- Setting the stage for full and partial template specialization docs
    - Tested and verified breathe source build via requirements.txt
    - Current version installed same as what is hosted through pip
    - Should be up to date enough for templates, release is ~3 days old
    - Electing to keep 'breathe' rather than git
        - Build time is exceptionally slow, it seems it may rebuild every time?

# Configuring Existing RTD for Python3

- Go to the **Admin** page for nanogui on RTD
    - Advanced Settings Tab
    - Near bottom: **Python interpreter:** select CPython 3.x

Everything else should stay the same, it will automatically reinstall things when you make the switch.

Between the time I started with exhale and now it seems breathe has had some updates, and is fully python 3 compatible :)  By virtue of switching to CPython 3.x through RTD, it will install the newest breathe via `pip3` (I think? If you check the build logs, there are mixed `python3` and `python` calls...)