### PR TITLE
Preprocessor guards for GL version-specific code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "ext/nanovg"]
     path = ext/nanovg
-    url = https://github.com/wjakob/nanovg
+    url = https://github.com/zooxco/nanovg
 [submodule "ext/glfw"]
     path = ext/glfw
     url = https://github.com/wjakob/glfw

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,12 @@ else()
   set(NANOGUI_USE_GLAD_DEFAULT OFF)
 endif()
 
-option(NANOGUI_BUILD_EXAMPLE "Build NanoGUI example application?" ON)
-option(NANOGUI_BUILD_SHARED  "Build NanoGUI as a shared library?" ON)
-option(NANOGUI_BUILD_PYTHON  "Build a Python plugin for NanoGUI?" ON)
-option(NANOGUI_USE_GLAD      "Use Glad OpenGL loader library?" ${NANOGUI_USE_GLAD_DEFAULT})
-option(NANOGUI_INSTALL       "Install NanoGUI on `make install`?" ON)
+option(NANOGUI_BUILD_EXAMPLE         "Build NanoGUI example application?" ON)
+option(NANOGUI_BUILD_SHARED          "Build NanoGUI as a shared library?" ON)
+option(NANOGUI_BUILD_PYTHON          "Build a Python plugin for NanoGUI?" ON)
+option(NANOGUI_USE_GLAD              "Use Glad OpenGL loader library?" ${NANOGUI_USE_GLAD_DEFAULT})
+option(NANOGUI_INSTALL               "Install NanoGUI on `make install`?" ON)
+option(NANOGUI_DEFAULT_GL_VERSION    "Default to GL3 compatability?"      ON)
 
 set(NANOGUI_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling the Python plugin")
 
@@ -73,6 +74,11 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw" "ext_build/glfw")
+
+# GL Version support: add NANOVG_GL3_IMPLEMENTATION unless disabled
+if (NANOGUI_DEFAULT_GL_VERSION)
+  list(APPEND NANOGUI_EXTRA_DEFS -DNANOVG_GL3_IMPLEMENTATION)
+endif()
 
 # Python support: add NANOGUI_PYTHON flag to all targets
 if (NANOGUI_BUILD_PYTHON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,12 +18,13 @@ else()
   set(NANOGUI_USE_GLAD_DEFAULT OFF)
 endif()
 
-option(NANOGUI_BUILD_EXAMPLE         "Build NanoGUI example application?" ON)
-option(NANOGUI_BUILD_SHARED          "Build NanoGUI as a shared library?" ON)
-option(NANOGUI_BUILD_PYTHON          "Build a Python plugin for NanoGUI?" ON)
-option(NANOGUI_USE_GLAD              "Use Glad OpenGL loader library?" ${NANOGUI_USE_GLAD_DEFAULT})
-option(NANOGUI_INSTALL               "Install NanoGUI on `make install`?" ON)
-option(NANOGUI_DEFAULT_GL_VERSION    "Default to GL3 compatability?"      ON)
+option(NANOGUI_BUILD_EXAMPLE            "Build NanoGUI example application?"           ON)
+option(NANOGUI_BUILD_SHARED             "Build NanoGUI as a shared library?"           ON)
+option(NANOGUI_BUILD_PYTHON             "Build a Python plugin for NanoGUI?"           ON)
+option(NANOGUI_USE_GLAD                 "Use Glad OpenGL loader library?" ${NANOGUI_USE_GLAD_DEFAULT})
+option(NANOGUI_INSTALL                  "Install NanoGUI on `make install`?"           ON)
+option(NANOGUI_DEFAULT_GL_VERSION       "Default to GL3 compatability?"                ON)
+option(NANOGUI_STB_IMAGE_IMPLEMENTATION "Include global stb_image symbols in library?" ON)
 
 set(NANOGUI_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling the Python plugin")
 
@@ -78,6 +79,12 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw" "ext_build/glfw")
 # GL Version support: add NANOVG_GL3_IMPLEMENTATION unless disabled
 if (NANOGUI_DEFAULT_GL_VERSION)
   list(APPEND NANOGUI_EXTRA_DEFS -DNANOVG_GL3_IMPLEMENTATION)
+endif()
+
+# STB Image: include global symbols for NanoVG's stb_image library
+# Disable this if linking with another library which uses stb_image
+if (NANOGUI_STB_IMAGE_IMPLEMENTATION)
+  list(APPEND NANOGUI_EXTRA_DEFS -DNANOVG_STB_IMAGE_IMPLEMENTATION)
 endif()
 
 # Python support: add NANOGUI_PYTHON flag to all targets

--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -16,6 +16,10 @@
 
 #include <nanogui/widget.h>
 
+#if defined(NANOVG_GL2_IMPLEMENTATION) || defined(NANOVG_GLES2_IMPLEMENTATION)
+#define NANOGUI_CURSOR_DISABLED
+#endif
+
 NAMESPACE_BEGIN(nanogui)
 
 /**
@@ -183,8 +187,10 @@ public:
 protected:
     GLFWwindow *mGLFWWindow;
     NVGcontext *mNVGContext;
+#if !defined(NANOGUI_CURSOR_DISABLED)
     GLFWcursor *mCursors[(int) Cursor::CursorCount];
     Cursor mCursor;
+#endif
     std::vector<Widget *> mFocusPath;
     Vector2i mFBSize;
     float mPixelRatio;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -70,10 +70,8 @@ void mainloop(int refresh) {
                 std::chrono::milliseconds time(refresh);
                 while (mainloop_active) {
                     std::this_thread::sleep_for(time);
-#ifndef NANOVG_GLES2_IMPLEMENTATION
-#ifndef NANOVG_GL2_IMPLEMENTATION
+#if !defined(NANOVG_GL2_IMPLEMENTATION) && !defined(NANOVG_GLES2_IMPLEMENTATION)
                     glfwPostEmptyEvent();
-#endif
 #endif
                 }
             }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -70,7 +70,11 @@ void mainloop(int refresh) {
                 std::chrono::milliseconds time(refresh);
                 while (mainloop_active) {
                     std::this_thread::sleep_for(time);
+#ifndef NANOVG_GLES2_IMPLEMENTATION
+#ifndef NANOVG_GL2_IMPLEMENTATION
                     glfwPostEmptyEvent();
+#endif
+#endif
                 }
             }
         );

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -426,7 +426,11 @@ void Screen::drawWidgets() {
 #endif
 
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
+#ifndef NANOVG_GL2_IMPLEMENTATION
+#ifndef NANOVG_GLES2_IMPLEMENTATION
     glBindSampler(0, 0);
+#endif
+#endif
     nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
 
     draw(mNVGContext);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -32,7 +32,7 @@
 #endif
 
 /* Allow enforcing the GL2 implementation of NanoVG */
-#define NANOVG_GL3_IMPLEMENTATION
+//#define NANOVG_GL3_IMPLEMENTATION
 #include <nanovg_gl.h>
 
 NAMESPACE_BEGIN(nanogui)

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -42,24 +42,24 @@ static bool gladInitialized = false;
 #endif
 
 inline NVGcontext* nvgCreateContext(int flags) {
-#if defined NANOVG_GL2_IMPLEMENTATION
+#if defined(NANOVG_GL2_IMPLEMENTATION)
   return nvgCreateGL2(flags);
-#elif defined NANOVG_GL3_IMPLEMENTATION
+#elif defined(NANOVG_GL3_IMPLEMENTATION)
   return nvgCreateGL3(flags);
-#elif defined NANOVG_GLES2_IMPLEMENTATION
+#elif defined(NANOVG_GLES2_IMPLEMENTATION)
   return nvgCreateGLES2(flags);
-#elif defined NANOVG_GLES3_IMPLEMENTATION
+#elif defined(NANOVG_GLES3_IMPLEMENTATION)
   return nvgCreateGLES3(flags);
 #endif
 }
 inline void nvgDeleteContext(NVGcontext* ctx) {
-#if defined NANOVG_GL2_IMPLEMENTATION
+#if defined(NANOVG_GL2_IMPLEMENTATION)
   nvgDeleteGL2(ctx);
-#elif defined NANOVG_GL3_IMPLEMENTATION
+#elif defined(NANOVG_GL3_IMPLEMENTATION)
   nvgDeleteGL3(ctx);
-#elif defined NANOVG_GLES2_IMPLEMENTATION
+#elif defined(NANOVG_GLES2_IMPLEMENTATION)
   nvgDeleteGLES2(ctx);
-#elif defined NANOVG_GLES3_IMPLEMENTATION
+#elif defined(NANOVG_GLES3_IMPLEMENTATION)
   nvgDeleteGLES3(ctx);
 #endif
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -43,6 +43,29 @@ std::map<GLFWwindow *, Screen *> __nanogui_screens;
 static bool gladInitialized = false;
 #endif
 
+inline NVGcontext* nvgCreateContext(int flags) {
+#if defined NANOVG_GL2_IMPLEMENTATION
+  return nvgCreateGL2(flags);
+#elif defined NANOVG_GL3_IMPLEMENTATION
+  return nvgCreateGL3(flags);
+#elif defined NANOVG_GLES2_IMPLEMENTATION
+  return nvgCreateGLES2(flags);
+#elif defined NANOVG_GLES3_IMPLEMENTATION
+  return nvgCreateGLES3(flags);
+#endif
+}
+inline void nvgDeleteContext(NVGcontext* ctx) {
+#if defined NANOVG_GL2_IMPLEMENTATION
+  nvgDeleteGL2(ctx);
+#elif defined NANOVG_GL3_IMPLEMENTATION
+  nvgDeleteGL3(ctx);
+#elif defined NANOVG_GLES2_IMPLEMENTATION
+  nvgDeleteGLES2(ctx);
+#elif defined NANOVG_GLES3_IMPLEMENTATION
+  nvgDeleteGLES3(ctx);
+#endif
+}
+
 /* Calculate pixel ratio for hi-dpi devices. */
 static float get_pixel_ratio(GLFWwindow *window) {
 #if defined(_WIN32)
@@ -213,6 +236,8 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
         }
     );
 
+#ifndef NANOVG_GL2_IMPLEMENTATION
+#ifndef NANOVG_GLES2_IMPLEMENTATION
     glfwSetDropCallback(mGLFWWindow,
         [](GLFWwindow *w, int count, const char **filenames) {
             auto it = __nanogui_screens.find(w);
@@ -224,6 +249,8 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
             s->dropCallbackEvent(count, filenames);
         }
     );
+#endif
+#endif
 
     glfwSetScrollCallback(mGLFWWindow,
         [](GLFWwindow *w, double x, double y) {
@@ -295,7 +322,7 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
     flags |= NVG_DEBUG;
 #endif
 
-    mNVGContext = nvgCreateGL3(flags);
+    mNVGContext = nvgCreateContext(flags);
     if (mNVGContext == nullptr)
         throw std::runtime_error("Could not initialize NanoVG!");
 
@@ -319,7 +346,7 @@ Screen::~Screen() {
             glfwDestroyCursor(mCursors[i]);
     }
     if (mNVGContext)
-        nvgDeleteGL3(mNVGContext);
+        nvgDeleteContext(mNVGContext);
     if (mGLFWWindow && mShutdownGLFWOnDestruct)
         glfwDestroyWindow(mGLFWWindow);
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -50,6 +50,8 @@ inline NVGcontext* nvgCreateContext(int flags) {
   return nvgCreateGLES2(flags);
 #elif defined(NANOVG_GLES3_IMPLEMENTATION)
   return nvgCreateGLES3(flags);
+#else
+#error No NANOVG_GL*_IMPLEMENTATION macro defined
 #endif
 }
 inline void nvgDeleteContext(NVGcontext* ctx) {
@@ -61,6 +63,8 @@ inline void nvgDeleteContext(NVGcontext* ctx) {
   nvgDeleteGLES2(ctx);
 #elif defined(NANOVG_GLES3_IMPLEMENTATION)
   nvgDeleteGLES3(ctx);
+#else
+#error No NANOVG_GL*_IMPLEMENTATION macro defined
 #endif
 }
 


### PR DESCRIPTION
When attempting to run NanoGUI under GLES2, a number of GL3 functions were not available. This pull guards against those with preprocessor `#ifdef`s, and removes the hard-coded `#define NANOVG_GL3_IMPLEMENTATION` in `src/screen.cpp`