### PR TITLE
Reorder python version list, assume if user has higher python3 versio…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -412,7 +412,7 @@ if (NANOGUI_BUILD_PYTHON)
 
   # Try to autodetect Python (can be overridden manually if needed)
   list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/ext/pybind11/tools")
-  set(Python_ADDITIONAL_VERSIONS 3.4 3.5 3.6 3.7)
+  set(Python_ADDITIONAL_VERSIONS 3.7 3.6 3.5 3.4)
   find_package(PythonLibsNew ${MITSUBA_PYTHON_VERSION})
   if (NOT PYTHONLIBS_FOUND)
     # Python not found -- disable the plugin


### PR DESCRIPTION
…n they intend to use it.

I primarily operate on Fedora, which by default includes python 3.4.  I recently discovered the [matmul operator](https://docs.python.org/3/library/operator.html#operator.matmul) and decided to upgrade to 3.5.2.

The current build system will grab python 3.4 by default, this switch just makes it so that a higher version takes precedence when building the python bindings.  It seems reasonable to assume that if somebody has a higher version they'd want to use it.

#174 fixes `MITSUBA_PYTHON_VERSION` to be `NANOGUI_PYTHON_VERSION`, and with either available this PR doesn't do too much / may not be warranted...just makes it so I don't have to specify anything explicitly when running `cmake` ;)