### PR TITLE
Warn if NVIDIA OpenGL Headers are detected.

### DIFF
--- a/include/nanogui/opengl.h
+++ b/include/nanogui/opengl.h
@@ -34,6 +34,16 @@
 #include <GLFW/glfw3.h>
 #include <nanovg.h>
 
+// Special treatment of linux Nvidia opengl headers
+#if !defined(_WIN32) && !defined(__APPLE__)
+  #if !defined(GL_UNIFORM_BUFFER)
+    #warning NanoGUI suspects you have the NVIDIA OpenGL headers installed.  \
+             Compilation will likely fail. If it does, you have two choices: \
+             (1) Re-install the mesa-libGL header files.                     \
+             (2) Compile with NANOGUI_USE_GLAD.
+  #endif
+#endif
+
 NAMESPACE_BEGIN(nanogui)
 
 /// Allows for conversion between nanogui::Color and the NanoVG NVGcolor class.


### PR DESCRIPTION
On Linux, the mesa-libGL headers are more permissive than the headers
installed by the NVIDIA graphics installer if --opengl-headers was
requested during installation.  The error message informs the user of
their options so they hopefully do not spend much time discerning the
cause of the problem.

Resolves https://github.com/wjakob/nanogui/issues/156

Works as expected, the user gets inundated with `warning` messages and an eventual failed compilation.  A serial build once more would give the following warn-error cycle:

```
sven:~/Desktop/mein/nanogui/perceval_build> make
[ 20%] Built target glfw_objects
[ 22%] Building CXX object CMakeFiles/nanogui-obj.dir/src/glutil.cpp.o
In file included from /home/sven/Desktop/mein/nanogui/src/glutil.cpp:12:
In file included from /home/sven/Desktop/mein/nanogui/include/nanogui/glutil.h:15:
/home/sven/Desktop/mein/nanogui/include/nanogui/opengl.h:40:6: warning: NanoGUI suspects you have the NVIDIA OpenGL headers installed. Compilation will likely fail. If it does, you have two choices: (1)
      Re-install the mesa-libGL header files. (2) Compile with NANOGUI_USE_GLAD. [-W#warnings]
    #warning NanoGUI suspects you have the NVIDIA OpenGL headers installed.  \
     ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:56:26: error: use of undeclared identifier 'GL_GEOMETRY_SHADER'
        else if (type == GL_GEOMETRY_SHADER)
                         ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:100:29: error: use of undeclared identifier 'GL_GEOMETRY_SHADER'
        createShader_helper(GL_GEOMETRY_SHADER, name, defines, geometry_str);
                            ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:146:25: error: use of undeclared identifier 'glGetUniformBlockIndex'
    GLuint blockIndex = glGetUniformBlockIndex(mProgramShader, name.c_str());
                        ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:147:23: error: use of undeclared identifier 'GL_INVALID_INDEX'
    if (blockIndex == GL_INVALID_INDEX) {
                      ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:152:5: error: use of undeclared identifier 'glUniformBlockBinding'
    glUniformBlockBinding(mProgramShader, blockIndex, buf.getBindingPoint());
    ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:307:22: error: use of undeclared identifier 'GL_UNIFORM_BUFFER'
    glBindBufferBase(GL_UNIFORM_BUFFER, mBindingPoint, mID);
                     ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:311:22: error: use of undeclared identifier 'GL_UNIFORM_BUFFER'
    glBindBufferBase(GL_UNIFORM_BUFFER, mBindingPoint, 0);
                     ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:320:18: error: use of undeclared identifier 'GL_UNIFORM_BUFFER'
    glBindBuffer(GL_UNIFORM_BUFFER, mID);
                 ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:321:18: error: use of undeclared identifier 'GL_UNIFORM_BUFFER'
    glBufferData(GL_UNIFORM_BUFFER, data.size(), data.data(), GL_DYNAMIC_DRAW);
                 ^
/home/sven/Desktop/mein/nanogui/src/glutil.cpp:322:18: error: use of undeclared identifier 'GL_UNIFORM_BUFFER'
    glBindBuffer(GL_UNIFORM_BUFFER, 0);
                 ^
1 warning and 10 errors generated.
CMakeFiles/nanogui-obj.dir/build.make:119: recipe for target 'CMakeFiles/nanogui-obj.dir/src/glutil.cpp.o' failed
make[2]: *** [CMakeFiles/nanogui-obj.dir/src/glutil.cpp.o] Error 1
CMakeFiles/Makefile2:179: recipe for target 'CMakeFiles/nanogui-obj.dir/all' failed
make[1]: *** [CMakeFiles/nanogui-obj.dir/all] Error 2
Makefile:127: recipe for target 'all' failed
make: *** [all] Error 2
```

I'm pretty sure the `#warning` directive across lines like that is ok, it wraps just fine in my terminal if I resize, but there may be something I'm not aware of.