### PR TITLE
[docs] Do not specify bin2c, as it is no longer a target

### DIFF
--- a/docs/compilation.rst
+++ b/docs/compilation.rst
@@ -76,7 +76,7 @@ file as follows (this assumes that ``nanogui`` lives in the directory
     add_subdirectory(ext/nanogui)
 
     # For reliability of parallel build, make the NanoGUI targets dependencies
-    set_property(TARGET glfw glfw_objects bin2c nanogui PROPERTY FOLDER "dependencies")
+    set_property(TARGET glfw glfw_objects nanogui PROPERTY FOLDER "dependencies")
 
 Required Variables Exposed
 ----------------------------------------------------------------------------------------


### PR DESCRIPTION
I am using NanoGUI as a Git submodule in my project, as recommended in `docs/compilation.rst`. The instructions need updating due to the recent removal of `bin2c` as a target.