### PR TITLE
[docs] fixing link_title so templates do not have name trimmed

### DIFF
--- a/docs/exhale.py
+++ b/docs/exhale.py
@@ -2,7 +2,7 @@
 #
 # This file was generated on/around (date -Ru):
 #
-#             Tue, 08 Nov 2016 07:18:48 +0000
+#             Sun, 15 Jan 2017 05:53:44 +0000
 #
 # Copyright (c) 2016, Stephen McDowell
 # All rights reserved.
@@ -1007,10 +1007,11 @@ class ExhaleNode:
                     opening_li = '<li>'
                 # turn double underscores into underscores, then underscores into hyphens
                 html_link = self.link_name.replace("__", "_").replace("_", "-")
-                # should always have two parts
+                # should always have at least two parts (templates will have more)
                 title_as_link_parts = self.title.split(" ")
                 qualifier = title_as_link_parts[0]
-                link_title = title_as_link_parts[1]
+                link_title = " ".join(title_as_link_parts[1:])
+                link_title = link_title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                 html_link = '{} <a href="{}.html#{}">{}</a>'.format(qualifier,
                                                                     self.file_name.split('.rst')[0],
                                                                     html_link,
@@ -1154,10 +1155,11 @@ class ExhaleNode:
                     opening_li = '<li>'
                 # turn double underscores into underscores, then underscores into hyphens
                 html_link = self.link_name.replace("__", "_").replace("_", "-")
-                # should always have two parts
+                # should always have at least two parts (templates will have more)
                 title_as_link_parts = self.title.split(" ")
                 qualifier = title_as_link_parts[0]
-                link_title = title_as_link_parts[1]
+                link_title = " ".join(title_as_link_parts[1:])
+                link_title = link_title.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                 html_link = '{} <a href="{}.html#{}">{}</a>'.format(qualifier,
                                                                     self.file_name.split('.rst')[0],
                                                                     html_link,

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-breathe==4.3.1
+breathe==4.3.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-breathe==4.3.0
+breathe==4.2.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
-breathe==4.2.0
+Sphinx==1.3.5
+breathe==4.4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,1 @@
-breathe
-# git+git://github.com/michaeljones/breathe@v4.3.1#egg=breathe
+breathe==4.3.1

--- a/include/nanogui/serializer/core.h
+++ b/include/nanogui/serializer/core.h
@@ -151,22 +151,36 @@ NAMESPACE_BEGIN(detail)
  */
 template <typename T, typename SFINAE = void> struct serialization_traits { };
 
-// bypass template specializations for now
-#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/// Serialization id for ``int8_t`` is ``u8``.
 template <> struct serialization_traits<int8_t>           { const char *type_id = "u8";  };
+/// Serialization id for ``uint8_t`` is ``s8``.
 template <> struct serialization_traits<uint8_t>          { const char *type_id = "s8";  };
+/// Serialization id for ``int16_t`` is ``u16``.
 template <> struct serialization_traits<int16_t>          { const char *type_id = "u16"; };
+/// Serialization id for ``uint16_t`` is ``s16``.
 template <> struct serialization_traits<uint16_t>         { const char *type_id = "s16"; };
+/// Serialization id for ``int32_t`` is ``u32``.
 template <> struct serialization_traits<int32_t>          { const char *type_id = "u32"; };
+/// Serialization id for ``uint32_t`` is ``s32``.
 template <> struct serialization_traits<uint32_t>         { const char *type_id = "s32"; };
+/// Serialization id for ``int64_t`` is ``u64``.
 template <> struct serialization_traits<int64_t>          { const char *type_id = "u64"; };
+/// Serialization id for ``uint64_t`` is ``s64``.
 template <> struct serialization_traits<uint64_t>         { const char *type_id = "s64"; };
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
+/// Serialization id for ``half_float::half`` is ``f16``.
 template <> struct serialization_traits<half_float::half> { const char *type_id = "f16"; };
+#endif
+/// Serialization id for ``float`` is ``f32``.
 template <> struct serialization_traits<float>            { const char *type_id = "f32"; };
+/// Serialization id for ``double`` is ``f64``.
 template <> struct serialization_traits<double>           { const char *type_id = "f64"; };
+/// Serialization id for ``bool`` is ``b8``.
 template <> struct serialization_traits<bool>             { const char *type_id = "b8";  };
+/// Serialization id for ``char`` is ``c8``.
 template <> struct serialization_traits<char>             { const char *type_id = "c8";  };
 
+#ifndef DOXYGEN_SHOULD_SKIP_THIS
 template <typename T> struct serialization_traits<T> :
     serialization_traits<typename std::underlying_type<T>::type,
                          typename std::enable_if<std::is_enum<T>::value>::type> { };


### PR DESCRIPTION
Hey @wjakob I actually got lucky, not much had to change for things to work...I think.

I don't know if you've looked at the docs recently, but something has gone terribly wrong lately.  I posted [an issue](https://github.com/michaeljones/breathe/issues/303) on breathe's page, but titles for almost everything are getting deleted.

I see two possible options:

1. Hard-code a specific (earlier) version of breathe in `requirements.txt`
2. Try and use [this stuff](https://github.com/arximboldi/immer/commit/e6e3c3f7d8ed4ade23928c3db56ca90108d02b85).  I haven't tested this, and it is definitely not going to fix everything for us here.

I made this a PR to start a discussion, but this should not be merged in as is.