### PR TITLE
Allow Screen to receive drag events.

### DIFF
--- a/python/glutil.cpp
+++ b/python/glutil.cpp
@@ -181,9 +181,30 @@ void register_glutil(py::module &m) {
                            GLenum dfactor) { glBlendFunc(sfactor, dfactor); },
            py::arg("sfactor"), py::arg("dfactor"));
     gl.def("Scissor", [](GLint x, GLint y, GLsizei w, GLsizei h) { glScissor(x, y, w, h); });
+    gl.def("Viewport", [](GLint x, GLint y, GLsizei w, GLsizei h) { glViewport(x, y, w, h); });
     gl.def("Cull", [](GLenum mode) { glCullFace(mode); });
     gl.def("PointSize", [](GLfloat size) { glPointSize(size); });
     gl.def("LineWidth", [](GLfloat size) { glLineWidth(size); });
+    gl.def("DepthMask", [](bool flag) { glDepthMask(flag); });
+
+    gl.def("ClearDepth", [](GLdouble depth) { glClearDepth(depth); });
+    gl.def("GenOneBuffer", []()->GLuint { GLuint vbo = 0; glGenBuffers(1, &vbo); return vbo; });
+    gl.def("BindBuffer", [](GLenum target, GLuint buffer) { glBindBuffer(target, buffer); }, py::arg("target"), py::arg("buffer"));
+    gl.def("BufferData", [](GLenum target, GLsizeiptr size, py::array data, GLenum usage) {
+      glBufferData(target, size, data.data(), usage); },
+      py::arg("target"), py::arg("size"), py::arg("data"), py::arg("usage"));
+    gl.def("BufferSubData", [](GLenum target, GLintptr offset, GLsizeiptr size, py::array data) {
+      glBufferSubData(target, offset, size, data.data()); },
+      py::arg("target"), py::arg("offset"), py::arg("size"), py::arg("data"));
+    gl.def("GenOneVertexArray", []()->GLuint {GLuint b = 0; glGenVertexArrays(1, &b); return b; });
+    gl.def("BindVertexArray", [](GLuint vbo) { glBindVertexArray(vbo); });
+    gl.def("EnableVertexAttribArray", [](GLuint vbo) { glEnableVertexAttribArray(vbo); });
+    gl.def("DisableVertexAttribArray", [](GLuint vbo) { glDisableVertexAttribArray(vbo); });
+    gl.def("VertexAttribPointer", [](GLuint index, GLint size, GLenum type, bool normalized, GLsizei stride, GLsizeiptr pointer) {
+      glVertexAttribPointer(index, size, type, normalized, stride, reinterpret_cast<const void *>(pointer)); },
+      py::arg("index"), py::arg("size"), py::arg("type"), py::arg("normalized"), py::arg("stride"), py::arg("pointer"));
+    gl.def("DrawArray", [](GLenum mode, GLint first, GLsizei count) { glDrawArrays(mode, first, count); },
+      py::arg("mode"), py::arg("first"), py::arg("count"));
 
     /* Primitive types */
     C(POINTS); C(LINE_STRIP); C(LINE_LOOP); C(LINES); C(LINE_STRIP_ADJACENCY);
@@ -191,7 +212,8 @@ void register_glutil(py::module &m) {
     C(TRIANGLE_STRIP_ADJACENCY); C(TRIANGLES_ADJACENCY);
 
     /* Depth testing */
-    C(DEPTH_TEST); C(NEVER); C(LESS); C(EQUAL); C(LEQUAL); C(GREATER);
+    C(DEPTH_TEST); C(DEPTH_CLAMP);
+    C(NEVER); C(LESS); C(EQUAL); C(LEQUAL); C(GREATER);
     C(NOTEQUAL); C(GEQUAL); C(ALWAYS);
 
     /* Blend functions */
@@ -207,6 +229,18 @@ void register_glutil(py::module &m) {
     /* Remaining glEnable/glDisable enums */
     C(SCISSOR_TEST); C(STENCIL_TEST); C(PROGRAM_POINT_SIZE);
     C(LINE_SMOOTH); C(POLYGON_SMOOTH); C(CULL_FACE);
+
+    /* Buffer types*/
+    C(ARRAY_BUFFER);
+
+    /* Vertex attribute types*/
+    C(FLOAT);
+
+    /* Usage types*/
+    C(STREAM_DRAW); C(STREAM_READ); C(STREAM_COPY);
+    C(STATIC_DRAW); C(STATIC_READ); C(STATIC_COPY);
+    C(DYNAMIC_DRAW); C(DYNAMIC_READ); C(DYNAMIC_COPY);
+
 }
 
 #endif

--- a/src/glutil.cpp
+++ b/src/glutil.cpp
@@ -47,7 +47,7 @@ static GLuint createShader_helper(GLint type, const std::string &name,
     glGetShaderiv(id, GL_COMPILE_STATUS, &status);
 
     if (status != GL_TRUE) {
-        char buffer[512];
+      char buffer[512] = { 0 };
         std::cerr << "Error while compiling ";
         if (type == GL_VERTEX_SHADER)
             std::cerr << "vertex shader";

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -488,8 +488,8 @@ bool Screen::cursorPosCallbackEvent(double x, double y) {
             }
         } else {
             ret = mDragWidget->mouseDragEvent(
-                p - mDragWidget->parent()->absolutePosition(), p - mMousePos,
-                mMouseState, mModifiers);
+                (mDragWidget->parent() != nullptr) ? p - mDragWidget->parent()->absolutePosition() : p,
+                p - mMousePos, mMouseState, mModifiers);
         }
 
         if (!ret)
@@ -526,8 +526,8 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
         if (mDragActive && action == GLFW_RELEASE &&
             dropWidget != mDragWidget)
             mDragWidget->mouseButtonEvent(
-                mMousePos - mDragWidget->parent()->absolutePosition(), button,
-                false, mModifiers);
+                (mDragWidget->parent() != nullptr) ? mMousePos - mDragWidget->parent()->absolutePosition() : mMousePos,
+                button, false, mModifiers);
 
         if (dropWidget != nullptr && dropWidget->cursor() != mCursor) {
             mCursor = dropWidget->cursor();
@@ -536,8 +536,6 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
 
         if (action == GLFW_PRESS && (button == GLFW_MOUSE_BUTTON_1 || button == GLFW_MOUSE_BUTTON_2)) {
             mDragWidget = findWidget(mMousePos);
-            if (mDragWidget == this)
-                mDragWidget = nullptr;
             mDragActive = mDragWidget != nullptr;
             if (!mDragActive)
                 updateFocus(nullptr);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -534,7 +534,7 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
             glfwSetCursor(mGLFWWindow, mCursors[(int) mCursor]);
         }
 
-        if (action == GLFW_PRESS && (button == GLFW_MOUSE_BUTTON_1 || button == GLFW_MOUSE_BUTTON_2)) {
+        if (action == GLFW_PRESS && (button == GLFW_MOUSE_BUTTON_1 || button == GLFW_MOUSE_BUTTON_2 || button == GLFW_MOUSE_BUTTON_3)) {
             mDragWidget = findWidget(mMousePos);
             mDragActive = mDragWidget != nullptr;
             if (!mDragActive)


### PR DESCRIPTION
This will allow overriding of mouseDragEvent of the Screen object. Very handy for google earth type of application where the background of the whole app is the main display of 3D scene.