### PR TITLE
[docs] Add link to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ thanks to [NanoVG](https://github.com/memononen/NanoVG) by Mikko Mononen.
 Python bindings of all functionality are provided using
 [pybind11](https://github.com/wjakob/pybind11).
 
+- [Documentation](https://nanogui.readthedocs.io)
+
 ## Example screenshot
 ![Screenshot](https://github.com/wjakob/nanogui/raw/master/resources/screenshot.png "Screenshot")
 


### PR DESCRIPTION
Noticed some documentation in the `docs/` folder, and searched the [issue section](https://github.com/wjakob/nanogui/issues/47#issuecomment-244861955) for clues as to where it may be hosted.

Let's make it official!

- https://nanogui.readthedocs.io