### PR TITLE
Add initial setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,78 @@
+import os
+import re
+import sys
+import platform
+import subprocess
+
+from setuptools import setup, Distribution, Extension
+from setuptools.command.build_ext import build_ext
+from distutils.version import LooseVersion
+
+
+class BinaryDistribution(Distribution):
+    """Distribution which always forces a binary package with platform name"""
+    def has_ext_modules(foo):
+        return True
+
+
+class CMakeExtension(Extension):
+    def __init__(self, name, sourcedir=''):
+        Extension.__init__(self, name, sources=[])
+        self.sourcedir = os.path.abspath(sourcedir)
+
+
+class CMakeBuild(build_ext):
+    def run(self):
+        try:
+            out = subprocess.check_output(['cmake', '--version'])
+        except OSError:
+            raise RuntimeError("CMake must be installed to build the following extensions: " +
+                               ", ".join(e.name for e in self.extensions))
+
+        if platform.system() == "Windows":
+            cmake_version = LooseVersion(re.search(r'version\s*([\d.]+)', out.decode()).group(1))
+            if cmake_version < '3.1.0':
+                raise RuntimeError("CMake >= 3.1.0 is required on Windows")
+
+        for ext in self.extensions:
+            self.build_extension(ext)
+
+    def build_extension(self, ext):
+        extdir = os.path.abspath(os.path.dirname(self.get_ext_fullpath(ext.name)))
+        cmake_args = ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=' + extdir,
+                      '-DPYTHON_EXECUTABLE=' + sys.executable]
+
+        cfg = 'Debug' if self.debug else 'Release'
+        build_args = ['--config', cfg]
+
+        if platform.system() == "Windows":
+            cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
+            if sys.maxsize > 2**32:
+                cmake_args += ['-A', 'x64']
+            build_args += ['--', '/m']
+        else:
+            cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]
+            build_args += ['--', '-j2']
+
+        env = os.environ.copy()
+        env['CXXFLAGS'] = '{} -DVERSION_INFO=\\"{}\\"'.format(env.get('CXXFLAGS', ''),
+                                                              self.distribution.get_version())
+        if not os.path.exists(self.build_temp):
+            os.makedirs(self.build_temp)
+        subprocess.check_call(['cmake', ext.sourcedir] + cmake_args, cwd=self.build_temp, env=env)
+        subprocess.check_call(['cmake', '--build', '.'] + build_args, cwd=self.build_temp)
+
+setup(
+    name='nanogui',
+    version='0.0.1',
+    author='Dean Moldovan',
+    author_email='dean0x7d@gmail.com',
+    description='Bindings for nanogui',
+    long_description='',
+    ext_modules=[CMakeExtension('nanogui', sourcedir='..')],
+    cmdclass=dict(build_ext=CMakeBuild),
+    package_data={"nanogui": ["nanogui.so"]},
+    distclass=BinaryDistribution,
+    zip_safe=False,
+)
+


### PR DESCRIPTION
Initial setup.py 

Don't merge, pull request for conversation 

This calls cmake to build nanogui if you run ```python setup.py install```.

It is not useful yet for at least these reasons:

Needs to create a package containing the .so that can be installed.

It also probably makes sense to separate the python part and have that use nanogui as a subproject.


I got stuck on both the above as I'm a bit weak on native libraries for python.