### PR TITLE
Update to Eigen 3.3.3

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -376,8 +376,8 @@ void Screen::drawWidgets() {
     glfwGetWindowSize(mGLFWWindow, &mSize[0], &mSize[1]);
 
 #if defined(_WIN32) || defined(__linux__)
-    mSize = (mSize / mPixelRatio).cast<int>();
-    mFBSize = (mSize * mPixelRatio).cast<int>();
+    mSize = (mSize.cast<float>() / mPixelRatio).cast<int>();
+    mFBSize = (mSize.cast<float>() * mPixelRatio).cast<int>();
 #else
     /* Recompute pixel ratio on OSX */
     if (mSize[0])


### PR DESCRIPTION
This updates nanogui to work with Eigen 3.3.3. The only code change required was a small bit in screen.cpp. 
 Eigen 3.3.3 doesn't support multiplying or dividing an integer vector through by a float; this fixes the code that relied on that behavior by first casting the `mSize` vector to a float type, multiplying by the pixel ratio, and then casting that result back to an integer.