### PR TITLE
fixes for compiling with cmake generated Xcode project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -336,10 +336,27 @@ add_library(nanogui-obj OBJECT
   src/serializer.cpp
 )
 
-add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
-  $<TARGET_OBJECTS:nanogui-obj>
-  $<TARGET_OBJECTS:glfw_objects>
-)
+# XCode has a serious bug where the XCode project produces an invalid target that will not get
+# linked if it consists only of objects from object libraries, it will not generate any
+# products (executables, libraries). The only work around is to add a dummy source
+# file to the library definition. This is an XCode, not a CMake bug.
+# see https://itk.org/Bug/view.php?id=14044
+if(CMAKE_GENERATOR STREQUAL Xcode)
+  set(XCODE_DUMMY ${CMAKE_BINARY_DIR}/xcode_dummy.cpp)
+  file(WRITE ${XCODE_DUMMY} "")
+  add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
+    ${XCODE_DUMMY}
+    $<TARGET_OBJECTS:nanogui-obj>
+    $<TARGET_OBJECTS:glfw_objects>
+  )
+else()
+  add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
+    $<TARGET_OBJECTS:nanogui-obj>
+    $<TARGET_OBJECTS:glfw_objects>
+  )
+endif()
+
+
 
 if (NANOGUI_BUILD_SHARED)
   set_property(TARGET nanogui-obj PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -49,9 +49,13 @@
 #  pragma warning(disable: 4457 4456 4005 4312)
 #endif
 
-// the STB image functions are already defined in nanovg, if we import the header here,
-// get duplicate symbols if statically linking. 
-//#define STB_IMAGE_IMPLEMENTATION
+// On Unix, the STB functions get exported because they are included in nanovg,
+// importing them here causes static linking to fail because of duplicate symbols.
+// Windows does not export these in nanovg, so have to include the stb file
+// with implementation.
+#if defined(_WIN32)
+#  define STB_IMAGE_IMPLEMENTATION
+#endif
 #include <stb_image.h>
 
 #if defined(_WIN32)

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -49,7 +49,9 @@
 #  pragma warning(disable: 4457 4456 4005 4312)
 #endif
 
-#define STB_IMAGE_IMPLEMENTATION
+// the STB image functions are already defined in nanovg, if we import the header here,
+// get duplicate symbols if statically linking. 
+//#define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 
 #if defined(_WIN32)

--- a/src/example4.cpp
+++ b/src/example4.cpp
@@ -50,8 +50,6 @@
 #  pragma warning(disable: 4457 4456 4005 4312)
 #endif
 
-#define STB_IMAGE_IMPLEMENTATION
-#include <stb_image.h>
 
 #if defined(_WIN32)
 #  pragma warning(pop)


### PR DESCRIPTION
Hi, 

I added a few fixes that enables compilation of nanogui with CMake generated Xcode projects. Xcode has a bug, and I've implemented the CMake suggested work around. 

I've verified that this fix works for both Xcode generated projects, and CMake generated makefiles. 