### PR TITLE
update linux travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ matrix:
     - os: osx
       compiler: clang
       script:
+        - cmake --version
         - cmake -DNANOGUI_PYTHON_VERSION=2.7
         - make -j 2
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: cpp
+dist: trusty
 sudo: false
 matrix:
   include:
@@ -16,9 +17,15 @@ matrix:
             - python3.5-dev
             - python3.5-venv
             - libglu1-mesa-dev
-            - libxxf86vm-dev 
+            - libxxf86vm-dev
+            - libxrandr-dev
+            - libxinerama-dev
+            - libxcursor-dev
+            - libxi-dev
+            - libx11-dev
             - cmake
       script:
+        - cmake --version
         - cmake -DNANOGUI_USE_GLAD=ON -DNANOGUI_PYTHON_VERSION=3.5 -DPYTHON_INCLUDE_DIRS:PATH=/usr/include/python3.5m -DPYTHON_LIBRARY:FILEPATH=/usr/lib/x86_64-linux-gnu/libpython3.5m.so -DCMAKE_CXX_COMPILER=g++-4.8 -DCMAKE_C_COMPILER=gcc-4.8
         - make -j 2
     - os: osx


### PR DESCRIPTION
- Note: this is using `cmake 3.2.2`, not `2.8.12`.
    - It seems it used to come from `kubuntu-backports`, but does not anymore.
    - The only other whitelisted package I could find had `2.8.11`.  See discussion [here](https://github.com/travis-ci/apt-source-whitelist/issues/118)
- It seems you can alternatively install `cmake` from source
    - Meh. It would be nice if they just whitelisted the linked issue.  OSX is using [`cmake 3.6.2`](https://travis-ci.org/wjakob/nanogui/jobs/239823812#L62), so I suppose it is a bad idea not to have `2.8.12` in there.
- No trusted `2.8.12` PPA are available on travis at this time.
- Added some (missing?) linux gfx build deps.

Should allow #220, #222, and #223 to build now.

Build results: [travis-ci on my fork](https://travis-ci.org/svenevs/nanogui/builds/239808315)

**Warning**: see explanation on [travis docs](https://docs.travis-ci.com/user/trusty-ci-environment/), officially it is still in Beta.  I tried it and it just worked TM, but it may not actually be what you want in which case I'll just close this PR.  What about keeping Trusty but building `cmake 2.8.12` from source?