### PR TITLE
Context menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,7 @@ add_library(nanogui-obj OBJECT
   include/nanogui/stackedwidget.h src/stackedwidget.cpp
   include/nanogui/tabheader.h src/tabheader.cpp
   include/nanogui/tabwidget.h src/tabwidget.cpp
+  include/nanogui/contextmenu.h src/contextmenu.cpp
   include/nanogui/glcanvas.h src/glcanvas.cpp
   include/nanogui/formhelper.h
   include/nanogui/toolbutton.h

--- a/include/nanogui/contextmenu.h
+++ b/include/nanogui/contextmenu.h
@@ -17,98 +17,125 @@
 
 NAMESPACE_BEGIN(nanogui)
 
+/**
+ * \class ContextMenu contextmenu.h nanogui/contextmenu.h
+ * 
+ * \brief Nestable context menu.
+ * 
+ * A context menu may be used in either 'disposable' or 'non-disposable' mode.
+ * In disposable mode, it may be created and activated on-the-fly in an event
+ * handler, and the menu will automatically delete itself after use.
+ * In non-disposable mode, it may be created and stored before it is actually
+ * needed, and then activated inside an event handler. In this mode the menu
+ * instance is reusable as long as its parent is alive.
+ *
+ * \rst
+ * .. code-block:: cpp
+ *
+ *    auto menu = new ContextMenu(this, true);
+ *    menu->addItem("Item 1", [](){
+ *      std::cout << "Item 1 clicked!" << std::endl; 
+ *    });
+ *    auto submenu = menu->addSubMenu("Submenu 1");
+ *    submenu->addItem("Subitem 1", [](){
+ *      std::cout << "Subitem 1 clicked!"
+ *    });
+ *    menu->activate();
+ *
+ * \endrst
+ */
+class NANOGUI_EXPORT ContextMenu : public Widget {
+public:
     /**
-     * \class ContextMenu contextmenu.h nanogui/contextmenu.h
-     * 
-     * \brief Nestable context menu.
+     * \brief Construct a new ContextMenu.
+     * \param parent Parent widget.
+     * \param disposable When true, the context menu and all submenus will be
+     *                   destroyed upon deactivation.
      */
-    class NANOGUI_EXPORT ContextMenu : public Widget {
-    public:
-        /**
-         * \brief Construct a new ContextMenu.
-         * \param parent Parent widget.
-         * \param disposable When true, the context menu will be destroyed upon deactivation.
-         */
-        ContextMenu(Widget* parent, bool disposable);
+    ContextMenu(Widget* parent, bool disposable);
 
-        /**
-         * \brief Activate the context menu at the given position.
-         * Make the context menu visible. When an item is clicked, the context menu will be deactivated.
-         * \param pos The desired position of the top left corner of the context menu, relative to the parent.
-         */
-        void activate(const Vector2i& pos);
+    /**
+     * \brief Activate the context menu at the given position.
+     *
+     * Make the context menu visible. When an item is clicked, the context menu
+     * will be deactivated.
+     *
+     * \param pos The desired position of the top left corner of the context
+     *            menu, relative to the parent.
+     */
+    void activate(const Vector2i& pos);
 
-        /**
-         * \brief Deactivate the context menu.
-         * 
-         * This method is called automatically after an item is clicked. If the
-         * context menu is disposable, it will be removed from its parent and
-         * destroyed.
-         */
-        void deactivate();
+    /**
+     * \brief Deactivate the context menu.
+     * 
+     * This method is called automatically after an item is clicked. If the
+     * context menu is disposable, it will be removed from its parent and
+     * destroyed.
+     */
+    void deactivate();
 
-        /**
-         * \brief Add an item to the menu. The callback is called when the item is clicked.
-         * \param name Name of the item. The name is displayed in the context menu.
-         * \param cb Callback to be executed when the item is clicked.
-         * \param icon Optional icon to display to the left of the label.
-         */
-        void addItem(const std::string& name, const std::function<void()>& cb, int icon=0);
+    /**
+     * \brief Add an item to the menu. The callback is called when the item is clicked.
+     * \param name Name of the item. The name is displayed in the context menu.
+     * \param cb Callback to be executed when the item is clicked.
+     * \param icon Optional icon to display to the left of the label.
+     */
+    void addItem(const std::string& name, const std::function<void()>& cb, int icon=0);
 
-        /**
-         * Add a submenu to the menu.
-         *
-         * \param name The display text of the item.
-         * \returns nullptr if a submenu or item already exists under the given name.
-         * \param icon Optional icon to display to the left of the label.
-         */
-        ContextMenu* addSubMenu(const std::string& name, int icon = 0);
+    /**
+     * Add a submenu to the menu.
+     *
+     * \param name The display text of the item.
+     * \returns nullptr if a submenu or item already exists under the given name.
+     * \param icon Optional icon to display to the left of the label.
+     */
+    ContextMenu* addSubMenu(const std::string& name, int icon = 0);
 
-        Vector2i preferredSize(NVGcontext* ctx) const override;
-        bool mouseEnterEvent(const Vector2i& p, bool enter) override;
-        bool mouseMotionEvent(const Vector2i& p, const Vector2i& rel, int button, int modifiers) override;
-        bool mouseButtonEvent(const Vector2i& p, int button, bool down, int modifiers) override;
-        void draw(NVGcontext* ctx) override;
-        bool focusEvent(bool focused) override;
+    Vector2i preferredSize(NVGcontext* ctx) const override;
+    bool mouseEnterEvent(const Vector2i& p, bool enter) override;
+    bool mouseMotionEvent(const Vector2i& p, const Vector2i& rel, int button, int modifiers) override;
+    bool mouseButtonEvent(const Vector2i& p, int button, bool down, int modifiers) override;
+    void draw(NVGcontext* ctx) override;
+    bool focusEvent(bool focused) override;
 
-    protected:
-        /**
-         * \brief Determine if an item opens a new context menu.
-         * \param name Name of the item.
-         */
-        bool isSubMenu_(const std::string& name);
+protected:
+    /**
+     * \brief Determine if an item opens a new context menu.
+     * \param name Name of the item.
+     */
+    bool isSubMenu_(const std::string& name);
 
-        /**
-         * \brief Determine if a row contains the point `p`.
-         * \param name Name of the item that is on the desired row.
-         * \param p Point relative to self.
-         */
-        bool isRowSelected_(const std::string& name, const Vector2i& p) const;
+    /**
+     * \brief Determine if a row contains the point `p`.
+     * \param name Name of the item that is on the desired row.
+     * \param p Point relative to self.
+     */
+    bool isRowSelected_(const std::string& name, const Vector2i& p) const;
 
-    private:
-        /// Activate a submenu.
-        void activateSubmenu(const std::string& name);
-        /// Deactivate the currently active submenu if there is one.
-        void deactivateSubmenu();
-        /// Remove the context menu and all submenus from their parent widget.
-        void dispose();
-        /// Calculate a submenus position.
-        Vector2i submenuPosition(const std::string& name) const;
+private:
+    /// Activate a submenu.
+    void activateSubmenu(const std::string& name);
+    /// Deactivate the currently active submenu if there is one.
+    void deactivateSubmenu();
+    /// Remove the context menu and all submenus from their parent widget.
+    void dispose();
+    /// Calculate a submenus position.
+    Vector2i submenuPosition(const std::string& name) const;
 
-    private:
-        Widget *mItemContainer;
-        AdvancedGridLayout *mItemLayout;
-        std::unordered_map<std::string, std::function<void()>> mItems;
-        std::unordered_map<std::string, ContextMenu*> mSubmenus;
-        std::unordered_map<std::string, Label*> mLabels;
-        Label *mHighlightedItem;
-        ContextMenu *mActiveSubmenu;
-        ContextMenu *mRootMenu;
-        bool mDisposable;
-        bool mActivated;
-        bool mUpdateLayout;
+private:
+    Widget *mItemContainer;
+    AdvancedGridLayout *mItemLayout;
+    std::unordered_map<std::string, std::function<void()>> mItems;
+    std::unordered_map<std::string, ContextMenu*> mSubmenus;
+    std::unordered_map<std::string, Label*> mLabels;
+    Label *mHighlightedItem;
+    ContextMenu *mActiveSubmenu;
+    ContextMenu *mRootMenu;
+    bool mDisposable;
+    bool mActivated;
+    bool mUpdateLayout;
 
-        Color mBackgroundColor, mMarginColor, mHighlightColor;
-    };    
+    Color mBackgroundColor, mMarginColor, mHighlightColor;
+};    
 
 NAMESPACE_END(nanogui)

--- a/include/nanogui/contextmenu.h
+++ b/include/nanogui/contextmenu.h
@@ -1,0 +1,114 @@
+/*
+    nanogui/contextmenu.h -- Standard context menu with support for submenus
+
+    NanoGUI was developed by Wenzel Jakob <wenzel.jakob@epfl.ch>.
+    The widget drawing code is based on the NanoVG demo application
+    by Mikko Mononen.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+/** \file */
+
+#pragma once
+
+#include <nanogui/widget.h>
+#include <unordered_map>
+
+NAMESPACE_BEGIN(nanogui)
+
+    /**
+     * \class ContextMenu contextmenu.h nanogui/contextmenu.h
+     * 
+     * \brief Nestable context menu.
+     */
+    class NANOGUI_EXPORT ContextMenu : public Widget {
+    public:
+        /**
+         * \brief Construct a new ContextMenu.
+         * \param parent Parent widget.
+         * \param disposable When true, the context menu will be destroyed upon deactivation.
+         */
+        ContextMenu(Widget* parent, bool disposable);
+
+        /**
+         * \brief Activate the context menu at the given position.
+         * Make the context menu visible. When an item is clicked, the context menu will be deactivated.
+         * \param pos The desired position of the top left corner of the context menu, relative to the parent.
+         */
+        void activate(const Vector2i& pos);
+
+        /**
+         * \brief Deactivate the context menu.
+         * 
+         * This method is called automatically after an item is clicked. If the
+         * context menu is disposable, it will be removed from its parent and
+         * destroyed.
+         */
+        void deactivate();
+
+        /**
+         * \brief Add an item to the menu. The callback is called when the item is clicked.
+         * \param name Name of the item. The name is displayed in the context menu.
+         * \param cb Callback to be executed when the item is clicked.
+         * \param icon Optional icon to display to the left of the label.
+         */
+        void addItem(const std::string& name, const std::function<void()>& cb, int icon=0);
+
+        /**
+         * Add a submenu to the menu.
+         *
+         * \param name The display text of the item.
+         * \returns nullptr if a submenu or item already exists under the given name.
+         * \param icon Optional icon to display to the left of the label.
+         */
+        ContextMenu* addSubMenu(const std::string& name, int icon = 0);
+
+        Vector2i preferredSize(NVGcontext* ctx) const override;
+        bool mouseEnterEvent(const Vector2i& p, bool enter) override;
+        bool mouseMotionEvent(const Vector2i& p, const Vector2i& rel, int button, int modifiers) override;
+        bool mouseButtonEvent(const Vector2i& p, int button, bool down, int modifiers) override;
+        void draw(NVGcontext* ctx) override;
+        bool focusEvent(bool focused) override;
+
+    protected:
+        /**
+         * \brief Determine if an item opens a new context menu.
+         * \param name Name of the item.
+         */
+        bool isSubMenu_(const std::string& name);
+
+        /**
+         * \brief Determine if a row contains the point `p`.
+         * \param name Name of the item that is on the desired row.
+         * \param p Point relative to self.
+         */
+        bool isRowSelected_(const std::string& name, const Vector2i& p) const;
+
+    private:
+        /// Activate a submenu.
+        void activateSubmenu(const std::string& name);
+        /// Deactivate the currently active submenu if there is one.
+        void deactivateSubmenu();
+        /// Remove the context menu and all submenus from their parent widget.
+        void dispose();
+        /// Calculate a submenus position.
+        Vector2i submenuPosition(const std::string& name) const;
+
+    private:
+        Widget *mItemContainer;
+        AdvancedGridLayout *mItemLayout;
+        std::unordered_map<std::string, std::function<void()>> mItems;
+        std::unordered_map<std::string, ContextMenu*> mSubmenus;
+        std::unordered_map<std::string, Label*> mLabels;
+        Label *mHighlightedItem;
+        ContextMenu *mActiveSubmenu;
+        ContextMenu *mRootMenu;
+        bool mDisposable;
+        bool mActivated;
+        bool mUpdateLayout;
+
+        Color mBackgroundColor, mMarginColor, mHighlightColor;
+    };    
+
+NAMESPACE_END(nanogui)

--- a/include/nanogui/contextmenu.h
+++ b/include/nanogui/contextmenu.h
@@ -19,9 +19,9 @@ NAMESPACE_BEGIN(nanogui)
 
 /**
  * \class ContextMenu contextmenu.h nanogui/contextmenu.h
- * 
+ *
  * \brief Nestable context menu.
- * 
+ *
  * A context menu may be used in either 'disposable' or 'non-disposable' mode.
  * In disposable mode, it may be created and activated on-the-fly in an event
  * handler, and the menu will automatically delete itself after use.
@@ -34,7 +34,7 @@ NAMESPACE_BEGIN(nanogui)
  *
  *    auto menu = new ContextMenu(this, true);
  *    menu->addItem("Item 1", [](){
- *      std::cout << "Item 1 clicked!" << std::endl; 
+ *      std::cout << "Item 1 clicked!" << std::endl;
  *    });
  *    auto submenu = menu->addSubMenu("Submenu 1");
  *    submenu->addItem("Subitem 1", [](){
@@ -67,7 +67,7 @@ public:
 
     /**
      * \brief Deactivate the context menu.
-     * 
+     *
      * This method is called automatically after an item is clicked. If the
      * context menu is disposable, it will be removed from its parent and
      * destroyed.
@@ -136,6 +136,6 @@ private:
     bool mUpdateLayout;
 
     Color mBackgroundColor, mMarginColor, mHighlightColor;
-};    
+};
 
 NAMESPACE_END(nanogui)

--- a/include/nanogui/nanogui.h
+++ b/include/nanogui/nanogui.h
@@ -23,6 +23,7 @@
 #include <nanogui/toolbutton.h>
 #include <nanogui/popup.h>
 #include <nanogui/popupbutton.h>
+#include <nanogui/contextmenu.h>
 #include <nanogui/combobox.h>
 #include <nanogui/progressbar.h>
 #include <nanogui/entypo.h>

--- a/src/contextmenu.cpp
+++ b/src/contextmenu.cpp
@@ -19,17 +19,16 @@
 #include "nanogui/theme.h"
 
 NAMESPACE_BEGIN(nanogui)
-ContextMenu::ContextMenu(Widget* parent, bool disposable)
+ContextMenu::ContextMenu(Widget *parent, bool disposable)
     : Widget(parent),
-        mBackgroundColor(0.3f, 1.0f),
-        mMarginColor(0.28f, 1.0f),
-        mHighlightColor(0.15f, 1.0f),
         mHighlightedItem(nullptr),
         mActiveSubmenu(nullptr),
         mRootMenu(nullptr),
         mDisposable(disposable),
-        mActivated(false) 
-{
+        mActivated(false),
+        mBackgroundColor(0.3f, 1.0f),
+        mMarginColor(0.28f, 1.0f),
+        mHighlightColor(0.15f, 1.0f) {
     mItemContainer = new Widget(this);
     mItemContainer->setPosition({0,0});
     mItemLayout = new AdvancedGridLayout({10,0,0}, {}, 2);
@@ -96,7 +95,7 @@ ContextMenu* ContextMenu::addSubMenu(const std::string& name, int icon) {
         auto iconLbl = new Label(mItemContainer, utf8(icon).data(), "icons");
         iconLbl->setFontSize(fontSize()+2);
         mItemLayout->setAnchor(iconLbl, AdvancedGridLayout::Anchor{ 0,mItemLayout->rowCount() - 1,1,1 });
-    }        
+    }
     return mSubmenus[name];
 }
 
@@ -128,7 +127,7 @@ bool ContextMenu::mouseMotionEvent(const Vector2i& p, const Vector2i& rel, int b
             // Deactivate current submenu unless we are still hovering it.
             if (mActiveSubmenu && !(isSubMenu_(w.first) && mSubmenus[w.first] == mActiveSubmenu)) {
                 deactivateSubmenu();
-            }            
+            }
             // Activate the item we are hovering
             if (isSubMenu_(w.first) && mSubmenus[w.first] != mActiveSubmenu) {
                 activateSubmenu(w.first);
@@ -150,7 +149,7 @@ bool ContextMenu::mouseButtonEvent(const Vector2i& p, int button, bool down, int
                 std::function<void()> cb = mItems[w.first];
                 if (mRootMenu)
                     mRootMenu->deactivate();
-                else 
+                else
                     deactivate();
                 if (cb) cb();
                 return true;
@@ -193,8 +192,8 @@ void ContextMenu::draw(NVGcontext* ctx) {
     nvgRect(ctx, 0.5f, 0.5f, w - 1, h - 0.5f);
     nvgStrokeColor(ctx, mTheme->mBorderDark);
     nvgStroke(ctx);
-        
-    if (mHighlightedItem) {        
+
+    if (mHighlightedItem) {
         nvgBeginPath(ctx);
         nvgRect(ctx, 1, mHighlightedItem->position().y() + 1, w - 2, mHighlightedItem->height() - 2);
         nvgFillColor(ctx, mHighlightColor);

--- a/src/contextmenu.cpp
+++ b/src/contextmenu.cpp
@@ -1,0 +1,262 @@
+/*
+    src/contextmenu.cpp --  Standard context menu with support for submenus
+
+    NanoGUI was developed by Wenzel Jakob <wenzel.jakob@epfl.ch>.
+    The widget drawing code is based on the NanoVG demo application
+    by Mikko Mononen.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+#include <nanogui/contextmenu.h>
+#include <nanogui/screen.h>
+#include <nanogui/opengl.h>
+#include <nanogui/layout.h>
+#include <nanogui/serializer/core.h>
+#include <nanogui/entypo.h>
+#include "nanogui/label.h"
+#include "nanogui/theme.h"
+
+NAMESPACE_BEGIN(nanogui)
+ContextMenu::ContextMenu(Widget* parent, bool disposable)
+    : Widget(parent),
+        mBackgroundColor(0.3f, 1.0f),
+        mMarginColor(0.28f, 1.0f),
+        mHighlightColor(0.15f, 1.0f),
+        mHighlightedItem(nullptr),
+        mActiveSubmenu(nullptr),
+        mRootMenu(nullptr),
+        mDisposable(disposable),
+        mActivated(false) 
+{
+    mItemContainer = new Widget(this);
+    mItemContainer->setPosition({0,0});
+    mItemLayout = new AdvancedGridLayout({10,0,0}, {}, 2);
+    mItemLayout->setColStretch(0, 1.0f);
+    mItemContainer->setLayout(mItemLayout);
+    setVisible(false);
+}
+
+void ContextMenu::activate(const Vector2i& pos) {
+    setPosition(pos);
+    if (!mActivated) {
+        mActivated = true;
+        setVisible(true);
+        if (mRootMenu) {
+            mRootMenu->requestFocus();
+        }
+        else {
+            requestFocus();
+        }
+    }
+}
+
+void ContextMenu::deactivate() {
+    if (mActivated) {
+        mActivated = false;
+        setVisible(false);
+        deactivateSubmenu();
+        if (mDisposable) {
+            dispose();
+        }
+    }
+}
+
+void ContextMenu::addItem(const std::string& name, const std::function<void()>& value, int icon) {
+    mItems[name] = value;
+    auto lbl = new Label(mItemContainer, name);
+    mLabels[name] = lbl;
+    lbl->setFontSize(fontSize());
+    lbl->setHeight(lbl->fontSize() * 2);
+    mItemLayout->appendRow(0);
+    mItemLayout->setAnchor(lbl, AdvancedGridLayout::Anchor{1,mItemLayout->rowCount() - 1, 1, 1});
+    if (nvgIsFontIcon(icon)) {
+        auto iconLbl = new Label(mItemContainer, utf8(icon).data(), "icons");
+        iconLbl->setFontSize(fontSize()+2);
+        mItemLayout->setAnchor(iconLbl, AdvancedGridLayout::Anchor{ 0,mItemLayout->rowCount() - 1,1,1 });
+    }
+}
+
+ContextMenu* ContextMenu::addSubMenu(const std::string& name, int icon) {
+    if (!mParent)
+        return nullptr;
+    mSubmenus[name] = new ContextMenu(mParent, false);
+    mSubmenus[name]->mRootMenu = mRootMenu ? mRootMenu : this;
+    auto lbl1 = new Label(mItemContainer, name);
+    auto lbl2 = new Label(mItemContainer, utf8(ENTYPO_ICON_CHEVRON_THIN_RIGHT).data(), "icons");
+    mLabels[name] = lbl1;
+    lbl1->setFontSize(fontSize());
+    lbl1->setHeight(lbl1->fontSize() * 2);
+    lbl2->setFontSize(fontSize());
+    mItemLayout->appendRow(0);
+    mItemLayout->setAnchor(lbl1, AdvancedGridLayout::Anchor{1,mItemLayout->rowCount() - 1, 1, 1});
+    mItemLayout->setAnchor(lbl2, AdvancedGridLayout::Anchor{2,mItemLayout->rowCount() - 1, 1, 1});
+    if (nvgIsFontIcon(icon)) {
+        auto iconLbl = new Label(mItemContainer, utf8(icon).data(), "icons");
+        iconLbl->setFontSize(fontSize()+2);
+        mItemLayout->setAnchor(iconLbl, AdvancedGridLayout::Anchor{ 0,mItemLayout->rowCount() - 1,1,1 });
+    }        
+    return mSubmenus[name];
+}
+
+Vector2i ContextMenu::preferredSize(NVGcontext* ctx) const {
+    return mItemContainer->position() + mItemContainer->preferredSize(ctx);
+}
+
+bool ContextMenu::mouseEnterEvent(const Vector2i& p, bool enter) {
+    Widget::mouseEnterEvent(p, enter);
+    if (!enter) {
+        if (mActiveSubmenu) {
+            if (mActiveSubmenu->mMouseFocus)
+                mMouseFocus = true;
+            else
+                deactivateSubmenu();
+        } else if (mHighlightedItem) {
+            mHighlightedItem = nullptr;
+        }
+    }
+    return true;
+}
+
+bool ContextMenu::mouseMotionEvent(const Vector2i& p, const Vector2i& rel, int button, int modifiers) {
+    Widget::mouseMotionEvent(p, rel, button, modifiers);
+    Vector2i mousePos = p - mPos;
+    for (const auto& w : mLabels) {
+        // Deactivate old highlighted submenu, activate new submenu
+        if (isRowSelected_(w.first, mousePos)) {
+            // Deactivate current submenu unless we are still hovering it.
+            if (mActiveSubmenu && !(isSubMenu_(w.first) && mSubmenus[w.first] == mActiveSubmenu)) {
+                deactivateSubmenu();
+            }            
+            // Activate the item we are hovering
+            if (isSubMenu_(w.first) && mSubmenus[w.first] != mActiveSubmenu) {
+                activateSubmenu(w.first);
+            }
+            mHighlightedItem = mLabels[w.first];
+            break;
+        }
+    }
+    return true;
+}
+
+bool ContextMenu::mouseButtonEvent(const Vector2i& p, int button, bool down, int modifiers) {
+    Vector2i mousePos = p - mPos;
+    if (button==GLFW_MOUSE_BUTTON_LEFT && !down) {
+        // Preserve our existence in case the click destroys us.
+        ref<ContextMenu> buoy(this);
+        for (const auto& w : mLabels) {
+            if (isRowSelected_(w.first, mousePos) && !isSubMenu_(w.first)) {
+                std::function<void()> cb = mItems[w.first];
+                if (mRootMenu)
+                    mRootMenu->deactivate();
+                else 
+                    deactivate();
+                if (cb) cb();
+                return true;
+            }
+        }
+    }
+    return true;
+}
+
+void ContextMenu::draw(NVGcontext* ctx) {
+    nvgSave(ctx);
+    nvgTranslate(ctx, mPos.x(), mPos.y());
+
+    int w = mItemContainer->position().x() + mItemContainer->width();
+    int h = mItemContainer->position().y() + mItemContainer->height();
+
+    /* Draw background */
+    nvgBeginPath(ctx);
+    nvgRect(ctx, 0, 0, w, h);
+    nvgFillColor(ctx, mBackgroundColor);
+    nvgFill(ctx);
+
+    /* Draw margin background */
+    if (!mLabels.empty()) {
+        auto lbl = mLabels.begin()->second;
+        nvgBeginPath(ctx);
+        nvgRect(ctx, 0, 0, lbl->position().x()-1, h);
+        nvgFillColor(ctx, mMarginColor);
+        nvgFill(ctx);
+    }
+
+    /* Draw outline */
+    nvgBeginPath(ctx);
+    nvgStrokeWidth(ctx, 1.0f);
+    nvgRect(ctx, 0.5f, 1.5f, w - 1, h - 2);
+    nvgStrokeColor(ctx, mTheme->mBorderLight);
+    nvgStroke(ctx);
+
+    nvgBeginPath(ctx);
+    nvgRect(ctx, 0.5f, 0.5f, w - 1, h - 0.5f);
+    nvgStrokeColor(ctx, mTheme->mBorderDark);
+    nvgStroke(ctx);
+        
+    if (mHighlightedItem) {        
+        nvgBeginPath(ctx);
+        nvgRect(ctx, 1, mHighlightedItem->position().y() + 1, w - 2, mHighlightedItem->height() - 2);
+        nvgFillColor(ctx, mHighlightColor);
+        nvgFill(ctx);
+    }
+    nvgRestore(ctx);
+
+    Widget::draw(ctx);
+}
+
+bool ContextMenu::focusEvent(bool focused) {
+    Widget::focusEvent(focused);
+    // Deactivate when focus is lost
+    if (!focused) {
+        deactivate();
+    }
+    return true;
+}
+
+bool ContextMenu::isSubMenu_(const std::string& name) {
+    return mSubmenus.find(name) != mSubmenus.end();
+}
+
+bool ContextMenu::isRowSelected_(const std::string& name, const Vector2i& p) const {
+    if (mLabels.find(name) == mLabels.end())
+        return false;
+    auto w = mLabels.at(name);
+    int lblLeft = mItemContainer->position().x();
+    int lblRight = mItemContainer->position().x() + mItemContainer->width();
+    int lblTop = mItemContainer->position().y() + w->position().y();
+    int lblBot = mItemContainer->position().y() + w->position().y() + w->height();
+    return p.y() >= lblTop && p.y() < lblBot && p.x() >= lblLeft && p.x() < lblRight;
+}
+
+void ContextMenu::activateSubmenu(const std::string &name) {
+    if(mActiveSubmenu) {
+        deactivateSubmenu();
+    }
+    mActiveSubmenu = mSubmenus[name];
+    mActiveSubmenu->activate(submenuPosition(name));
+}
+
+void ContextMenu::deactivateSubmenu() {
+    if (mActiveSubmenu) {
+        mActiveSubmenu->deactivate();
+        mActiveSubmenu = nullptr;
+    }
+}
+
+void ContextMenu::dispose() {
+    for (const auto& w : mSubmenus)
+        w.second->dispose();
+    if (mParent) {
+        // Defer focus to parent widget before we destroy ourselves.
+        if (mFocused)
+            mParent->requestFocus();
+        mParent->removeChild(this);
+    }
+}
+
+Vector2i ContextMenu::submenuPosition(const std::string &name) const {
+    return mItemContainer->position() + Vector2i{ mItemContainer->width() - 1, mLabels.at(name)->position().y() + 1 } + mPos;
+}
+
+NAMESPACE_END(nanogui)

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -51,6 +51,7 @@
 
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
+#include <nanogui/contextmenu.h>
 
 #if defined(_WIN32)
 #  pragma warning(pop)
@@ -571,6 +572,28 @@ public:
         /* Draw 2 triangles starting at index 0 */
         mShader.drawIndexed(GL_TRIANGLES, 0, 2);
     }
+
+    bool mouseButtonEvent(const Eigen::Vector2i &p, int button, bool down, int modifiers) override {
+        if (Widget::mouseButtonEvent(p, button, down, modifiers))
+            return true;
+        if(down && button==GLFW_MOUSE_BUTTON_RIGHT && findWidget(p)==this) {
+            auto menu = new nanogui::ContextMenu(this, true);
+            menu->addItem("Item 1", [this]() { new nanogui::MessageDialog(this, nanogui::MessageDialog::Type::Information, "Item 1", "Item 1 Clicked!"); }, ENTYPO_ICON_CIRCLED_PLUS);
+
+            auto submenu = menu->addSubMenu("Submenu");
+            submenu->addItem("Subitem 1", [this]() { new nanogui::MessageDialog(this, nanogui::MessageDialog::Type::Information, "Subitem 1", "Subitem 1 Clicked!"); });
+            auto subsubmenu = submenu->addSubMenu("Subsubmenu", ENTYPO_ICON_LOOP);
+            submenu->addItem("Subitem 2", [this]() { new nanogui::MessageDialog(this, nanogui::MessageDialog::Type::Information, "Subitem 2", "Subitem 2 Clicked!"); });
+
+            subsubmenu->addItem("Subsubitem 1", [this]() { new nanogui::MessageDialog(this, nanogui::MessageDialog::Type::Information, "Subsubitem 1", "Subsubitem 1 Clicked!"); });
+            subsubmenu->addItem("Subsubitem 2", [this]() { new nanogui::MessageDialog(this, nanogui::MessageDialog::Type::Information, "Subsubitem 2", "Subsubitem 2 Clicked!"); });
+
+            menu->activate(p-mPos);
+            performLayout();
+        }
+        return true;
+    }
+
 private:
     nanogui::ProgressBar *mProgress;
     nanogui::GLShader mShader;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -626,12 +626,10 @@ bool Screen::resizeCallbackEvent(int, int) {
 }
 
 void Screen::updateFocus(Widget *widget) {
-    for (auto w: mFocusPath) {
-        if (!w->focused())
-            continue;
-        w->focusEvent(false);
-    }
+    // Save old focus path
+    auto oldFocusPath = mFocusPath;
     mFocusPath.clear();
+    // Generate new focus path
     Widget *window = nullptr;
     while (widget) {
         mFocusPath.push_back(widget);
@@ -639,6 +637,13 @@ void Screen::updateFocus(Widget *widget) {
             window = widget;
         widget = widget->parent();
     }
+    // Send unfocus events to widgets losing focus.
+    for (auto w : oldFocusPath) {
+        if (!w->focused() || find(mFocusPath.begin(), mFocusPath.end(), w) != mFocusPath.end())
+            continue;
+        w->focusEvent(false);
+    }
+    // Send focus events to widgets gaining focus.
     for (auto it = mFocusPath.rbegin(); it != mFocusPath.rend(); ++it)
         (*it)->focusEvent(true);
 


### PR DESCRIPTION
I recently created a context menu widget for my own project, and I thought it might be beneficial to others. This is just a standard context menu, the type that we are all familiar with. It supports arbitrarily nested submenus, and can delete itself automatically after it is done being used. This means it can be created directly inside an event handler. Here's a screenshot of example1 modified to open a context menu when right clicking the background:
![image](https://user-images.githubusercontent.com/3756179/28759913-57013184-7557-11e7-8c89-dd0288fe722e.png)

The context menu deactivates itself upon losing focus (i.e. when anything other than the menu is clicked on). To get this to work, I needed to make a small modification to the Screen::updateFocus method. The change simply avoids sending a de-focus event to widgets in the old focus path if that widget is also in the new focus path (meaning that widget is not really being de-focused anyway). I personally think this is more aligned with the expected behavior of the focus system, but if there is a reason it shouldn't be done this way I believe I could modify the context menu widget to work with the old behavior.

Unfortunately, I have not included python bindings yet because I'm having trouble with mkdoc.py. Could anyone guide me through the process of how py_doc.h should be generated?