### PR TITLE
Text truncation

### DIFF
--- a/include/nanogui/button.h
+++ b/include/nanogui/button.h
@@ -15,6 +15,9 @@
 #include <nanogui/widget.h>
 
 NAMESPACE_BEGIN(nanogui)
+
+enum class TextTruncation;
+
 /**
  * \class Button button.h nanogui/button.h
  *
@@ -48,6 +51,9 @@ public:
 
     const Color &textColor() const { return mTextColor; }
     void setTextColor(const Color &textColor) { mTextColor = textColor; }
+
+    TextTruncation textTruncation() const { return mTextTruncation; }
+    void setTextTruncation(TextTruncation truncation) { mTextTruncation = truncation; }
 
     int icon() const { return mIcon; }
     void setIcon(int icon) { mIcon = icon; }
@@ -87,6 +93,7 @@ protected:
     int mFlags;
     Color mBackgroundColor;
     Color mTextColor;
+    TextTruncation mTextTruncation;
     std::function<void()> mCallback;
     std::function<void(bool)> mChangeCallback;
     std::vector<Button *> mButtonGroup;

--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -130,6 +130,17 @@ enum class Cursor {
     CursorCount
 };
 
+/// Text trunctation options (Label, Button etc).
+enum class TextTruncation {
+    None,
+    Head,
+    Middle,
+    Tail
+};
+
+/// Return a string truncated to fit in availableWidth. Uses font face and size currently set on ctx.
+extern NANOGUI_EXPORT std::string truncateText(NVGcontext *ctx, const std::string &text, TextTruncation truncation, int availableWidth);
+
 /* Import some common Eigen types */
 using Eigen::Vector2f;
 using Eigen::Vector3f;

--- a/include/nanogui/label.h
+++ b/include/nanogui/label.h
@@ -16,6 +16,8 @@
 
 NAMESPACE_BEGIN(nanogui)
 
+enum class TextTruncation;
+
 /**
  * \class Label label.h nanogui/label.h
  *
@@ -44,6 +46,9 @@ public:
     /// Set the label color
     void setColor(const Color& color) { mColor = color; }
 
+    TextTruncation textTruncation() const { return mTextTruncation; }
+    void setTextTruncation(TextTruncation truncation) { mTextTruncation = truncation; }
+
     /// Set the \ref Theme used to draw this widget
     virtual void setTheme(Theme *theme) override;
 
@@ -59,6 +64,7 @@ protected:
     std::string mCaption;
     std::string mFont;
     Color mColor;
+    TextTruncation mTextTruncation;
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };

--- a/python/basics.cpp
+++ b/python/basics.cpp
@@ -21,7 +21,9 @@ void register_basics(py::module &m) {
         .def("font", &Label::font, D(Label, font))
         .def("setFont", &Label::setFont, D(Label, setFont))
         .def("color", &Label::color, D(Label, color))
-        .def("setColor", &Label::setColor, D(Label, setColor));
+        .def("setColor", &Label::setColor, D(Label, setColor))
+        .def("textTruncation", &Label::textTruncation, D(Label, textTruncation))
+        .def("setTextTruncation", &Label::setTextTruncation, D(Label, setTextTruncation));
 
 
     py::class_<Popup, Window, ref<Popup>, PyPopup> popup(m, "Popup", D(Popup));

--- a/python/button.cpp
+++ b/python/button.cpp
@@ -24,6 +24,8 @@ void register_button(py::module &m) {
         .def("setFlags", &Button::setFlags, D(Button, setFlags))
         .def("iconPosition", &Button::iconPosition, D(Button, iconPosition))
         .def("setIconPosition", &Button::setIconPosition, D(Button, setIconPosition))
+        .def("textTruncation", &Button::textTruncation, D(Button, textTruncation))
+        .def("setTextTruncation", &Button::setTextTruncation, D(Button, setTextTruncation))
         .def("pushed", &Button::pushed, D(Button, pushed))
         .def("setPushed", &Button::setPushed, D(Button, setPushed))
         .def("callback", &Button::callback, D(Button, callback))

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -232,6 +232,12 @@ PYBIND11_PLUGIN(nanogui) {
         .value("Horizontal", Orientation::Horizontal)
         .value("Vertical", Orientation::Vertical);
 
+    py::enum_<TextTruncation>(m, "TextTruncation", D(TextTruncation))
+        .value("None", TextTruncation::None)
+        .value("Head", TextTruncation::Head)
+        .value("Middle", TextTruncation::Middle)
+        .value("Tail", TextTruncation::Tail);
+
     register_constants(m);
     register_eigen(m);
     register_widget(m);

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -298,7 +298,11 @@ static const char *__doc_nanogui_Button_setPushed = R"doc()doc";
 
 static const char *__doc_nanogui_Button_setTextColor = R"doc()doc";
 
+static const char *__doc_nanogui_Button_setTextTruncation = R"doc()doc";
+
 static const char *__doc_nanogui_Button_textColor = R"doc()doc";
+
+static const char *__doc_nanogui_Button_textTruncation = R"doc()doc";
 
 static const char *__doc_nanogui_CheckBox = R"doc(Two-state check box widget.)doc";
 
@@ -1398,6 +1402,10 @@ R"doc(Set the currently active font (2 are available by default: 'sans' and
 
 static const char *__doc_nanogui_Label_setTheme = R"doc(Set the Theme used to draw this widget)doc";
 
+static const char *__doc_nanogui_Label_setTextTruncation = R"doc()doc";
+
+static const char *__doc_nanogui_Label_textTruncation = R"doc()doc";
+
 static const char *__doc_nanogui_Layout = R"doc(Basic interface of a layout engine.)doc";
 
 static const char *__doc_nanogui_Layout_performLayout = R"doc()doc";
@@ -2153,6 +2161,16 @@ static const char *__doc_nanogui_TextBox_unitsImage = R"doc()doc";
 static const char *__doc_nanogui_TextBox_updateCursor = R"doc()doc";
 
 static const char *__doc_nanogui_TextBox_value = R"doc()doc";
+
+static const char *__doc_nanogui_TextTruncation = R"doc(Text trunctation options (Label, Button etc).)doc";
+
+static const char *__doc_nanogui_TextTruncation_None = R"doc()doc";
+
+static const char *__doc_nanogui_TextTruncation_Head = R"doc()doc";
+
+static const char *__doc_nanogui_TextTruncation_Middle = R"doc()doc";
+
+static const char *__doc_nanogui_TextTruncation_Tail = R"doc()doc";
 
 static const char *__doc_nanogui_Theme = R"doc(Storage class for basic theme-related properties.)doc";
 

--- a/src/button.cpp
+++ b/src/button.cpp
@@ -254,7 +254,12 @@ bool Button::load(Serializer &s) {
     if (!s.get("flags", mFlags)) return false;
     if (!s.get("backgroundColor", mBackgroundColor)) return false;
     if (!s.get("textColor", mTextColor)) return false;
-    if (!s.get("textTruncation", mTextTruncation)) return false;
+
+    // "new" fields
+    const std::vector<std::string> keys = s.keys();
+    if (std::find(keys.begin(), keys.end(), "textTruncation") != keys.end()) {
+        if (!s.get("textTruncation", mTextTruncation)) return false;
+    }
     return true;
 }
 

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -21,6 +21,7 @@
 #include <chrono>
 #include <iostream>
 #include <algorithm>
+#include <cctype>
 
 #if !defined(_WIN32)
     #include <locale.h>

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -203,22 +203,19 @@ loadImageDirectory(NVGcontext *ctx, const std::string &path) {
     return result;
 }
 
-inline std::string ltrim(const std::string &s)
-{
+inline std::string ltrim(const std::string &s) {
     auto isspace = [](int c) { return std::isspace(c); };
     auto wsfront = std::find_if_not(s.begin(), s.end(), isspace);
     return std::string(wsfront, s.end());
 }
 
-inline std::string rtrim(const std::string &s)
-{
+inline std::string rtrim(const std::string &s) {
     auto isspace = [](int c) { return std::isspace(c); };
     auto wsback = std::find_if_not(s.rbegin(), s.rend(), isspace);
     return std::string(s.begin(), wsback.base());
 }
 
-inline std::string trim(const std::string &s)
-{
+inline std::string trim(const std::string &s) {
     auto isspace = [](int c) { return std::isspace(c); };
     auto  wsfront = std::find_if_not(s.begin(), s.end(), isspace);
     return std::string(wsfront, std::find_if_not(s.rbegin(), std::string::const_reverse_iterator(wsfront), isspace).base());

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -485,6 +485,37 @@ public:
             }
         });
 
+        window = new Window(this, "Text Truncation");
+        window->setPosition(Vector2i(710, 350));
+        window->setFixedWidth(220);
+        window->setLayout(new GroupLayout());
+
+        std::string longTitle = "A very, very, very, long button title";
+
+        new Label(window, "Truncate Head", "sans-bold");
+
+        b = new Button(window, longTitle);
+        b->setTextTruncation(TextTruncation::Head);
+        b->setTooltip(b->caption());
+
+        new Label(window, "Truncate Middle", "sans-bold");
+
+        b = new Button(window, longTitle);
+        b->setTextTruncation(TextTruncation::Middle);
+        b->setTooltip(b->caption());
+
+        new Label(window, "Truncate Tail", "sans-bold");
+
+        b = new Button(window, longTitle);
+        b->setTextTruncation(TextTruncation::Tail);
+        b->setTooltip(b->caption());
+
+        new Label(window, "Labels also", "sans-bold");
+
+        Label *l = new Label(window, "An even longer title, this time it's really, really long", "sans-bold");
+        l->setTextTruncation(TextTruncation::Tail);
+        l->setTooltip(b->caption());
+
         performLayout();
 
         /* All NanoGUI widgets are initialized at this point. Now

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -17,7 +17,7 @@
 NAMESPACE_BEGIN(nanogui)
 
 Label::Label(Widget *parent, const std::string &caption, const std::string &font, int fontSize)
-    : Widget(parent), mCaption(caption), mFont(font) {
+    : Widget(parent), mCaption(caption), mFont(font), mTextTruncation(TextTruncation::None) {
     if (mTheme) {
         mFontSize = mTheme->mStandardFontSize;
         mColor = mTheme->mTextColor;
@@ -57,12 +57,15 @@ void Label::draw(NVGcontext *ctx) {
     nvgFontFace(ctx, mFont.c_str());
     nvgFontSize(ctx, fontSize());
     nvgFillColor(ctx, mColor);
+
+    std::string caption = truncateText(ctx, mCaption, mTextTruncation, width());
+
     if (mFixedSize.x() > 0) {
         nvgTextAlign(ctx, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
-        nvgTextBox(ctx, mPos.x(), mPos.y(), mFixedSize.x(), mCaption.c_str(), nullptr);
+        nvgTextBox(ctx, mPos.x(), mPos.y(), mFixedSize.x(), caption.c_str(), nullptr);
     } else {
         nvgTextAlign(ctx, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-        nvgText(ctx, mPos.x(), mPos.y() + mSize.y() * 0.5f, mCaption.c_str(), nullptr);
+        nvgText(ctx, mPos.x(), mPos.y() + mSize.y() * 0.5f, caption.c_str(), nullptr);
     }
 }
 
@@ -71,6 +74,7 @@ void Label::save(Serializer &s) const {
     s.set("caption", mCaption);
     s.set("font", mFont);
     s.set("color", mColor);
+    s.set("textTruncation", mTextTruncation);
 }
 
 bool Label::load(Serializer &s) {
@@ -78,6 +82,7 @@ bool Label::load(Serializer &s) {
     if (!s.get("caption", mCaption)) return false;
     if (!s.get("font", mFont)) return false;
     if (!s.get("color", mColor)) return false;
+    if (!s.get("textTruncation", mTextTruncation)) return false;
     return true;
 }
 

--- a/src/label.cpp
+++ b/src/label.cpp
@@ -82,7 +82,12 @@ bool Label::load(Serializer &s) {
     if (!s.get("caption", mCaption)) return false;
     if (!s.get("font", mFont)) return false;
     if (!s.get("color", mColor)) return false;
-    if (!s.get("textTruncation", mTextTruncation)) return false;
+
+    // "new" fields
+    const std::vector<std::string> keys = s.keys();
+    if (std::find(keys.begin(), keys.end(), "textTruncation") != keys.end()) {
+        if (!s.get("textTruncation", mTextTruncation)) return false;
+    }
     return true;
 }
 


### PR DESCRIPTION
This is the first of a set of pull requests for changes we have generated as part of our use of nanogui in ColorFinale (http://try.colorgradingcentral.com/colorfinale/). ColorFinale is a plugin for Final Cut Pro X - we use nanogui for our on-screen controls.

This pull request adds support for truncating text where the text does not fit in the widget (Label/Button only).

I've added usage examples in example1.cpp