### PR TITLE
Removing use of -retain (incompatible with ARC).

### DIFF
--- a/src/darwin.mm
+++ b/src/darwin.mm
@@ -6,7 +6,7 @@ NAMESPACE_BEGIN(nanogui)
 std::string file_dialog(const std::vector<std::pair<std::string, std::string>> &filetypes, bool save) {
     std::string path = "";
     if (save) {
-        NSSavePanel *saveDlg = [[NSSavePanel savePanel] retain];
+        NSSavePanel *saveDlg = [NSSavePanel savePanel];
 
         NSMutableArray *types = [NSMutableArray new];
         for (size_t idx = 0; idx < filetypes.size(); ++idx)
@@ -17,7 +17,7 @@ std::string file_dialog(const std::vector<std::pair<std::string, std::string>> &
         if ([saveDlg runModal] == NSModalResponseOK)
             path = [[[saveDlg URL] path] UTF8String];
     } else {
-        NSOpenPanel *openDlg = [[NSOpenPanel openPanel] retain];
+        NSOpenPanel *openDlg = [NSOpenPanel openPanel];
 
         [openDlg setCanChooseFiles:YES];
         [openDlg setCanChooseDirectories:NO];


### PR DESCRIPTION
Non-ARC Objective-C projects are now very rare.

Note: the old code would have leaked without ARC anyway (no autorelease of "types" array).