### PR TITLE
Fixes crash caused by removing widget which has focus.

### DIFF
--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -160,7 +160,7 @@ public:
     }
 
     /// Walk up the hierarchy and return the parent window
-    Window *window();
+    Window *window() const;
 
     /// Associate this widget with an ID value (optional)
     void setId(const std::string &id) { mId = id; }

--- a/include/nanogui/window.h
+++ b/include/nanogui/window.h
@@ -45,6 +45,9 @@ public:
     /// Center the window in the current \ref Screen
     void center();
 
+    /// Return the window's \ref Screen.
+    Screen *screen() const;
+
     /// Draw the window
     virtual void draw(NVGcontext *ctx) override;
     /// Handle window drag events

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -142,17 +142,24 @@ void Window::draw(NVGcontext *ctx) {
 }
 
 void Window::dispose() {
-    Widget *widget = this;
-    while (widget->parent())
-        widget = widget->parent();
-    ((Screen *) widget)->disposeWindow(this);
+    screen()->disposeWindow(this);
 }
 
 void Window::center() {
-    Widget *widget = this;
-    while (widget->parent())
-        widget = widget->parent();
-    ((Screen *) widget)->centerWindow(this);
+    screen()->centerWindow(this);
+}
+
+Screen *Window::screen() const {
+    const Widget *parent = this->parent();
+    while (true) {
+        if (!parent)
+            throw std::runtime_error(
+                "Window:internal error (could not find parent screen)");
+        const Screen *screen = dynamic_cast<const Screen *>(parent);
+        if (screen)
+            return (Screen *)screen;
+        parent = parent->parent();
+    }
 }
 
 bool Window::mouseDragEvent(const Vector2i &, const Vector2i &rel,


### PR DESCRIPTION
Widgets now update the Screen's focus list if the child widget being removed has focus.

This fixed a recurring crash in our project.

Note: a full fix should recurse through any child widgets of the widget being removed to also check for focus. However there may be a more efficient method of handling this issue (e.g. query Screen's focusList ?).

