### PR TITLE
Do not require GLCanvas to have a parent window

### DIFF
--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -162,6 +162,9 @@ public:
     /// Walk up the hierarchy and return the parent window
     Window *window();
 
+    /// Walk up the hierarchy and return the parent screen
+    Screen *screen();
+
     /// Associate this widget with an ID value (optional)
     void setId(const std::string &id) { mId = id; }
     /// Return the ID value associated with this widget, if any

--- a/src/glcanvas.cpp
+++ b/src/glcanvas.cpp
@@ -46,7 +46,7 @@ void GLCanvas::draw(NVGcontext *ctx) {
     if (mDrawBorder)
         drawWidgetBorder(ctx);
 
-    const Screen* screen = dynamic_cast<const Screen*>(this->window()->parent());
+    const Screen* screen = this->screen();
     assert(screen);
 
     float pixelRatio = screen->pixelRatio();

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -182,6 +182,19 @@ Window *Widget::window() {
     }
 }
 
+Screen *Widget::screen() {
+    Widget *widget = this;
+    while (true) {
+        if (!widget)
+            throw std::runtime_error(
+                "Widget:internal error (could not find parent screen)");
+        Screen *screen = dynamic_cast<Screen *>(widget);
+        if (screen)
+            return screen;
+        widget = widget->parent();
+    }
+}
+
 void Widget::requestFocus() {
     Widget *widget = this;
     while (widget->parent())


### PR DESCRIPTION
Currently, `GLCanvas` needs to obtain the root `Screen` for drawing purposes, but does so by first finding the parent `Window` and then picking the parent of that. This has two problems:

1. A `Window` is not necessarily a direct descendant of `Screen`.
2. There may not be a `Window` between `GLCanvas` and `Screen` (my use case).

The simple fix is to directly recurse up the parents until the screen is found, rather than stopping by the `Window` first.