### PR TITLE
Allow file_dialog to open multiple files at once and fix undefined behavior with zenity

### DIFF
--- a/include/nanogui/common.h
+++ b/include/nanogui/common.h
@@ -464,6 +464,25 @@ extern NANOGUI_EXPORT std::string
 file_dialog(const std::vector<std::pair<std::string, std::string>> &filetypes,
             bool save);
 
+/**
+ * \brief Open a native file open dialog, which allows multiple selection.
+ *
+ * \param filetypes
+ *     Pairs of permissible formats with descriptions like
+ *     ``("png", "Portable Network Graphics")``.
+ *
+ * \param save
+ *     Set to ``true`` if you would like subsequent file dialogs to open
+ *     at whatever folder they were in when they close this one.
+ *
+ * \param multiple
+ *     Set to ``true`` if you would like to be able to select multiple
+ *     files at once. May not be simultaneously true with \p save.
+ */
+extern NANOGUI_EXPORT std::vector<std::string>
+file_dialog(const std::vector<std::pair<std::string, std::string>> &filetypes,
+            bool save, bool multiple);
+
 #if defined(__APPLE__) || defined(DOXYGEN_DOCUMENTATION_BUILD)
 /**
  * \brief Move to the application bundle's parent directory

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -207,7 +207,8 @@ PYBIND11_PLUGIN(nanogui) {
 
     m.def("leave", &nanogui::leave, D(leave));
     m.def("active", &nanogui::active, D(active));
-    m.def("file_dialog", &nanogui::file_dialog, D(file_dialog));
+    m.def("file_dialog", (std::string(*)(const std::vector<std::pair<std::string, std::string>> &, bool)) &nanogui::file_dialog, D(file_dialog));
+    m.def("file_dialog", (std::vector<std::string>(*)(const std::vector<std::pair<std::string, std::string>> &, bool, bool)) &nanogui::file_dialog, D(file_dialog));
     #if defined(__APPLE__)
         m.def("chdir_to_bundle_parent", &nanogui::chdir_to_bundle_parent);
     #endif

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -202,9 +202,18 @@ loadImageDirectory(NVGcontext *ctx, const std::string &path) {
     return result;
 }
 
-#if !defined(__APPLE__)
 std::string file_dialog(const std::vector<std::pair<std::string, std::string>> &filetypes, bool save) {
-#define FILE_DIALOG_MAX_BUFFER 1024
+    auto result = file_dialog(filetypes, save, false);
+    return result.empty() ? "" : result.front();
+}
+
+#if !defined(__APPLE__)
+std::vector<std::string> file_dialog(const std::vector<std::pair<std::string, std::string>> &filetypes, bool save, bool multiple) {
+    static const int FILE_DIALOG_MAX_BUFFER = 16384;
+    if (save && multiple) {
+        throw std::invalid_argument("save and multiple must not both be true.");
+    }
+
 #if defined(_WIN32)
     OPENFILENAME ofn;
     ZeroMemory(&ofn, sizeof(OPENFILENAME));
@@ -235,7 +244,7 @@ std::string file_dialog(const std::vector<std::pair<std::string, std::string>> &
         }
         filter.push_back('\0');
     }
-    for (auto pair: filetypes) {
+    for (auto pair : filetypes) {
         filter.append(pair.second);
         filter.append(" (*.");
         filter.append(pair.first);
@@ -251,21 +260,45 @@ std::string file_dialog(const std::vector<std::pair<std::string, std::string>> &
     if (save) {
         ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT;
         if (GetSaveFileNameA(&ofn) == FALSE)
-            return "";
+            return {};
     } else {
         ofn.Flags = OFN_EXPLORER | OFN_PATHMUSTEXIST | OFN_FILEMUSTEXIST;
+        if (multiple)
+            ofn.Flags |= OFN_ALLOWMULTISELECT;
         if (GetOpenFileNameA(&ofn) == FALSE)
-            return "";
+            return {};
     }
-    return std::string(ofn.lpstrFile);
+
+    size_t i = 0;
+    std::vector<std::string> result;
+    while (tmp[i] != '\0') {
+        result.emplace_back(&tmp[i]);
+        i += result.back().size() + 1;
+    }
+
+    if (result.size() > 1) {
+        for (i = 1; i < result.size(); ++i) {
+            result[i] = result[0] + "\\" + result[i];
+        }
+        result.erase(begin(result));
+    }
+
+    return result;
 #else
     char buffer[FILE_DIALOG_MAX_BUFFER];
+    buffer[0] = '\0';
+
     std::string cmd = "/usr/bin/zenity --file-selection ";
+    // The safest separator for multiple selected paths is /, since / can never occur
+    // in file names. Only where two paths are concatenated will there be two / following
+    // each other.
+    if (multiple)
+        cmd += "--multiple --separator=\"/\" ";
     if (save)
         cmd += "--save ";
     cmd += "--file-filter=\"";
-    for (auto pair: filetypes)
-        cmd += "\"*." + pair.first +  "\" ";
+    for (auto pair : filetypes)
+        cmd += "\"*." + pair.first + "\" ";
     cmd += "\"";
     FILE *output = popen(cmd.c_str(), "r");
     if (output == nullptr)
@@ -273,8 +306,21 @@ std::string file_dialog(const std::vector<std::pair<std::string, std::string>> &
     while (fgets(buffer, FILE_DIALOG_MAX_BUFFER, output) != NULL)
         ;
     pclose(output);
-    std::string result(buffer);
-    result.erase(std::remove(result.begin(), result.end(), '\n'), result.end());
+    std::string paths(buffer);
+    paths.erase(std::remove(paths.begin(), paths.end(), '\n'), paths.end());
+
+    std::vector<std::string> result;
+    while (!paths.empty()) {
+        size_t end = paths.find("//");
+        if (end == std::string::npos) {
+            result.emplace_back(paths);
+            paths = "";
+        } else {
+            result.emplace_back(paths.substr(0, end));
+            paths = paths.substr(end + 1);
+        }
+    }
+
     return result;
 #endif
 }


### PR DESCRIPTION
This PR introduces a little bit of code duplication, but I felt in these specific isolated cases of heavily OS-specific code it is acceptable. If you disagree, I'll be happy to refactor the code a bit. No strong preference.

Cheers!