### PR TITLE
Fixed potential crashes caused by dangling pointers.

### DIFF
--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -195,7 +195,7 @@ protected:
     int mMouseState, mModifiers;
     Vector2i mMousePos;
     bool mDragActive;
-    Widget *mDragWidget = nullptr;
+    ref<Widget> mDragWidget;
     double mLastInteraction;
     bool mProcessEvents;
     Color mBackground;

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -480,6 +480,12 @@ bool Screen::cursorPosCallbackEvent(double x, double y) {
     try {
         p -= Vector2i(1, 2);
 
+        // Make sure mDragWidget isn't the only remaining reference
+        if (mDragActive && mDragWidget->getRefCount() == 1) {
+            mDragActive = false;
+            mDragWidget = nullptr;
+        }
+
         if (!mDragActive) {
             Widget *widget = findWidget(p);
             if (widget != nullptr && widget->cursor() != mCursor) {
@@ -522,6 +528,12 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
         else
             mMouseState &= ~(1 << button);
 
+        // Make sure mDragWidget isn't the only remaining reference
+        if (mDragActive && mDragWidget->getRefCount() == 1) {
+            mDragActive = false;
+            mDragWidget = nullptr;
+        }
+
         auto dropWidget = findWidget(mMousePos);
         if (mDragActive && action == GLFW_RELEASE &&
             dropWidget != mDragWidget)
@@ -536,7 +548,7 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
 
         if (action == GLFW_PRESS && (button == GLFW_MOUSE_BUTTON_1 || button == GLFW_MOUSE_BUTTON_2)) {
             mDragWidget = findWidget(mMousePos);
-            if (mDragWidget == this)
+            if (mDragWidget.get() == this)
                 mDragWidget = nullptr;
             mDragActive = mDragWidget != nullptr;
             if (!mDragActive)
@@ -649,7 +661,7 @@ void Screen::updateFocus(Widget *widget) {
 void Screen::disposeWindow(Window *window) {
     if (std::find(mFocusPath.begin(), mFocusPath.end(), window) != mFocusPath.end())
         mFocusPath.clear();
-    if (mDragWidget == window)
+    if (mDragWidget.get() == window)
         mDragWidget = nullptr;
     removeChild(window);
 }

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -152,14 +152,21 @@ void Widget::addChild(Widget * widget) {
 }
 
 void Widget::removeChild(const Widget *widget) {
-    mChildren.erase(std::remove(mChildren.begin(), mChildren.end(), widget), mChildren.end());
-    widget->decRef();
+	auto it = std::find(mChildren.begin(), mChildren.end(), widget);
+	if (it == mChildren.end()) {
+		return;
+	}
+	removeChild(it - mChildren.begin());
 }
 
 void Widget::removeChild(int index) {
-    Widget *widget = mChildren[index];
-    mChildren.erase(mChildren.begin() + index);
-    widget->decRef();
+	Widget *widget = mChildren[index];
+	if (widget->focused()) {
+		requestFocus();
+	}
+
+	mChildren.erase(mChildren.begin() + index);
+	widget->decRef();
 }
 
 int Widget::childIndex(Widget *widget) const {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -152,21 +152,21 @@ void Widget::addChild(Widget * widget) {
 }
 
 void Widget::removeChild(const Widget *widget) {
-	auto it = std::find(mChildren.begin(), mChildren.end(), widget);
-	if (it == mChildren.end()) {
-		return;
-	}
-	removeChild(it - mChildren.begin());
+    auto it = std::find(mChildren.begin(), mChildren.end(), widget);
+    if (it == mChildren.end()) {
+        return;
+    }
+    removeChild(it - mChildren.begin());
 }
 
 void Widget::removeChild(int index) {
-	Widget *widget = mChildren[index];
-	if (widget->focused()) {
-		requestFocus();
-	}
+    Widget *widget = mChildren[index];
+    if (widget->focused()) {
+        requestFocus();
+    }
 
-	mChildren.erase(mChildren.begin() + index);
-	widget->decRef();
+    mChildren.erase(mChildren.begin() + index);
+    widget->decRef();
 }
 
 int Widget::childIndex(Widget *widget) const {


### PR DESCRIPTION
In the current version, mDragWidget is a raw pointer, which can cause crashes if the widget it points is removed. mDragWidget is set on mouse click, and if the same click also removes the widget, a crash occurs when the mouse is released due to a dangling pointer.