### PR TITLE
fix tabheader right icon position

### DIFF
--- a/src/tabheader.cpp
+++ b/src/tabheader.cpp
@@ -443,8 +443,9 @@ void TabHeader::drawControls(NVGcontext* ctx) {
     nvgTextAlign(ctx, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
     float yScaleRight = 0.5f;
     float xScaleRight = 1.0f - xScaleLeft - rightWidth / theme()->mTabControlWidth;
-    auto leftControlsPos = mPos.cast<float>() + Vector2f(mSize.cast<float>().x() - theme()->mTabControlWidth, 0);
-    Vector2f rightIconPos = leftControlsPos + Vector2f(xScaleRight*theme()->mTabControlWidth, yScaleRight*mSize.cast<float>().y());
+    Vector2f rightIconPos = mPos.cast<float>() + Vector2f(mSize.cast<float>().x(), mSize.cast<float>().y()*yScaleRight) -
+                            Vector2f(xScaleRight*theme()->mTabControlWidth + rightWidth, 0);
+
     nvgText(ctx, rightIconPos.x(), rightIconPos.y() + 1, iconRight.data(), nullptr);
 }
 


### PR DESCRIPTION
I'm having a really hard time debugging this, since the original works for me on OSX Sierra.  It's clearly got something to do with the positioning code.

Printout when I run it:

```
------------------------------
left pos:  4, 10
right pos: 224, 10
prev rpos: 221, 10
mPos:      0, 0
mSize:     240, 20
r width:   15
tab width: 20
------------------------------
```

`right pos` is the proposed new calculation that is currently getting applied.  `prev rpos` is what it used to be.  Can you run this and include the output / indicate whether the new positioning scheme is working for you?  I can't really reason about why it's breaking...the only thing I can think of is possible bad `float` / `int` conversion with the multiplication?