### PR TITLE
Fix for scaling on high-dpi screens when using KDE

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -485,7 +485,7 @@ bool Screen::cursorPosCallbackEvent(double x, double y) {
     Vector2i p((int) x, (int) y);
 
 #if defined(_WIN32) || defined(__linux__)
-    p /= mPixelRatio;
+    p = (p.cast<float>() / mPixelRatio).cast<int>();
 #endif
 
     bool ret = false;
@@ -620,7 +620,7 @@ bool Screen::resizeCallbackEvent(int, int) {
     glfwGetWindowSize(mGLFWWindow, &size[0], &size[1]);
 
 #if defined(_WIN32) || defined(__linux__)
-    size /= mPixelRatio;
+    size = (size.cast<float>() / mPixelRatio).cast<int>();
 #endif
 
     if (mFBSize == Vector2i(0, 0) || size == Vector2i(0, 0))

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -62,7 +62,7 @@ static float get_pixel_ratio(GLFWwindow *window) {
     if (GetDpiForMonitor_) {
         uint32_t dpiX, dpiY;
         if (GetDpiForMonitor_(monitor, 0 /* effective DPI */, &dpiX, &dpiY) == S_OK)
-            return std::round(dpiX / 96.0);
+            return dpiX / 96.0;
     }
     return 1.f;
 #elif defined(__linux__)


### PR DESCRIPTION
As discussed in 
https://github.com/wjakob/nanogui/issues/202
This fixes the UI scaling for systems which use KDE5. 
