### PR TITLE
Fix various python bindings

### DIFF
--- a/python/basics.cpp
+++ b/python/basics.cpp
@@ -58,7 +58,9 @@ void register_basics(py::module &m) {
         .value("Warning", MessageDialog::Type::Warning);
 
     py::class_<VScrollPanel, Widget, ref<VScrollPanel>, PyVScrollPanel>(m, "VScrollPanel", D(VScrollPanel))
-        .def(py::init<Widget *>(), py::arg("parent"), D(VScrollPanel, VScrollPanel));
+        .def(py::init<Widget *>(), py::arg("parent"), D(VScrollPanel, VScrollPanel))
+        .def("scroll", &VScrollPanel::scroll, D(VScrollPanel, scroll))
+        .def("setScroll", &VScrollPanel::setScroll, D(VScrollPanel, setScroll));
 
     py::class_<ComboBox, Widget, ref<ComboBox>, PyComboBox>(m, "ComboBox", D(ComboBox))
         .def(py::init<Widget *>(), py::arg("parent"), D(ComboBox, ComboBox))

--- a/python/main.cpp
+++ b/python/main.cpp
@@ -209,7 +209,7 @@ PYBIND11_PLUGIN(nanogui) {
     m.def("leave", &nanogui::leave, D(leave));
     m.def("active", &nanogui::active, D(active));
     m.def("file_dialog", (std::string(*)(const std::vector<std::pair<std::string, std::string>> &, bool)) &nanogui::file_dialog, D(file_dialog));
-    m.def("file_dialog", (std::vector<std::string>(*)(const std::vector<std::pair<std::string, std::string>> &, bool, bool)) &nanogui::file_dialog, D(file_dialog));
+    m.def("file_dialog", (std::vector<std::string>(*)(const std::vector<std::pair<std::string, std::string>> &, bool, bool)) &nanogui::file_dialog, D(file_dialog, 2));
     #if defined(__APPLE__)
         m.def("chdir_to_bundle_parent", &nanogui::chdir_to_bundle_parent);
     #endif

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -3384,7 +3384,15 @@ static const char *__doc_nanogui_VScrollPanel_preferredSize = R"doc()doc";
 
 static const char *__doc_nanogui_VScrollPanel_save = R"doc()doc";
 
+static const char *__doc_nanogui_VScrollPanel_scroll =
+R"doc(Return the current scroll amount as a value between 0 and 1. 0 means
+scrolled to the top and 1 to the bottom.)doc";
+
 static const char *__doc_nanogui_VScrollPanel_scrollEvent = R"doc()doc";
+
+static const char *__doc_nanogui_VScrollPanel_setScroll =
+R"doc(Set the scroll amount to a value between 0 and 1. 0 means scrolled to
+the top and 1 to the bottom.)doc";
 
 static const char *__doc_nanogui_Widget =
 R"doc(Base class of all widgets.

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -3928,6 +3928,21 @@ Parameter ``save``:
     Set to ``True`` if you would like subsequent file dialogs to open
     at whatever folder they were in when they close this one.)doc";
 
+static const char *__doc_nanogui_file_dialog_2 =
+R"doc(Open a native file open dialog, which allows multiple selection.
+
+Parameter ``filetypes``:
+    Pairs of permissible formats with descriptions like ``("png",
+    "Portable Network Graphics")``.
+
+Parameter ``save``:
+    Set to ``True`` if you would like subsequent file dialogs to open
+    at whatever folder they were in when they close this one.
+
+Parameter ``multiple``:
+    Set to ``True`` if you would like to be able to select multiple
+    files at once. May not be simultaneously true with \p save.)doc";
+
 static const char *__doc_nanogui_frustum =
 R"doc(Creates a perspective projection matrix.
 


### PR DESCRIPTION
- Adds missing python bindings for `VScrollPanel::scroll` and `VScrollPanel::setScroll` (see https://github.com/wjakob/nanogui/pull/255)
- Adds missing documentation string for python binding of `file_dialog` overload handling multiple selection (see https://github.com/wjakob/nanogui/pull/256)