### PR TITLE
allow const acquisition of Arcball's Quaternionf

### DIFF
--- a/include/nanogui/glutil.h
+++ b/include/nanogui/glutil.h
@@ -465,6 +465,8 @@ struct Arcball {
 
     Quaternionf &state() { return mQuat; }
 
+    const Quaternionf &state() const { return mQuat; }
+
     void setState(const Quaternionf &state) {
         mActive = false;
         mLastPos = Vector2i::Zero();

--- a/python/glutil.cpp
+++ b/python/glutil.cpp
@@ -140,7 +140,7 @@ void register_glutil(py::module &m) {
     py::class_<Arcball>(m, "Arcball", D(Arcball))
         .def(py::init<float>(), py::arg("speedFactor") = 2.f, D(Arcball, Arcball))
         .def(py::init<const Quaternionf &>(), D(Arcball, Arcball, 2))
-        .def("state", &Arcball::state, D(Arcball, state))
+        .def("state", (Quaternionf& (Arcball::*)()) &Arcball::state, D(Arcball, state))
         .def("setState", &Arcball::setState, D(Arcball, setState))
         .def("size", &Arcball::size, D(Arcball, size))
         .def("setSize", &Arcball::setSize, D(Arcball, setSize))


### PR DESCRIPTION
Needed for a scenario such as

```cpp
class ArcballCamera {
    //                               vvvv
    Eigen::Quaternionf getRotation() const {
        return mArcball.state();
    }
protected:
    nanogui::Arcball mArcball;
}
```

Maybe the desired signature would be `const Quaternionf &getState() const { return mQuat; }`?  The `const` part is the main problem, ref vs stacked quat aren't really a concern.