### PR TITLE
Documentation PR: add Fedora compiling instructions in README.md

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -185,6 +185,18 @@ To also get the Python bindings, you'll need to run
 
    $ apt-get install python-dev
 
+On RedHat/Fedora, make sure that you have installed the following packages
+
+.. code-block:: bash
+
+   $ sudo dnf install libXi-devel libXcursor-devel libXinerama-devel libXrandr-devel xorg-x11-server-devel
+
+To also get the Python bindings, you'll need to run
+
+.. code-block:: bash
+
+   $ sudo dnf install python3-devel
+
 License
 ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
Installing dev library on Fedora drove me crazy. I improved the documentation to help beginners.