### PR TITLE
Glutil permissions and some docs fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -553,6 +553,8 @@ else()
     list(APPEND MKDOC_CXX_FLAGS_LIST -I${value})
   endforeach()
 
+  # Make sure platform specific code gets kept in py_doc.h (specifically __doc_nanogui_chdir_to_bundle_parent)
+  list(APPEND MKDOC_COMPILE_DEFINITIONS "DOXYGEN_DOCUMENTATION_BUILD")
   foreach (value ${MKDOC_COMPILE_DEFINITIONS})
     list(APPEND MKDOC_CXX_FLAGS_LIST -D${value})
   endforeach()

--- a/docs/mkdoc_rst.py
+++ b/docs/mkdoc_rst.py
@@ -157,6 +157,8 @@ def process_comment(comment):
             s = s[2:].lstrip('*')
         elif s.endswith('*/'):
             s = s[:-2].rstrip('*')
+        elif s.startswith('///<'):
+            s = s[4:]
         elif s.startswith('///'):
             s = s[3:]
         if s.startswith('*'):
@@ -207,8 +209,8 @@ def process_comment(comment):
         'sa': 'See also',
         'see': 'See also',
         'extends': 'Extends',
-        'throw': 'Throws',
-        'throws': 'Throws'
+        'throws': 'Throws',
+        'throw': 'Throws'
     }.items():
         s = re.sub(r'\\%s\s*' % in_, r'\n\n$%s:\n\n' % out_, s)
 

--- a/docs/mkdoc_rst.py
+++ b/docs/mkdoc_rst.py
@@ -257,12 +257,10 @@ def process_comment(comment):
                 if len(line) < 4:
                     result += line.strip()
                 else:
-                    # this is a .. code-block:: indentation (three spaces)
+                    # this is a .. code-block:: indentation (three spaces),
+                    # strip leading three spaces, preserve remaining indentation
                     if line.startswith('   '):
-                        if line[3] != ' ': # outer-most indentation level
-                            result += line[3:].strip() + '\n'
-                        else:
-                            result += line[3:].rstrip() + '\n'
+                        result += line[3:].rstrip() + '\n'
                     else:
                         result += line.strip() + '\n'
         else:

--- a/docs/mkdoc_rst.py
+++ b/docs/mkdoc_rst.py
@@ -14,6 +14,7 @@
 #        s = re.sub(r'\\endrst', r'```\n\n', s)
 #        s = re.sub(r'.. note::', r'Note:', s)
 #        s = re.sub(r'.. warning::', r'Warning:', s)
+#        s = re.sub(r'.. danger::', r'Danger:', s)
 #        s = re.sub(r'.. code-block::\s*\w*', r'', s)
 #
 #  - process_comment: near the end, have to treat .. code-block:: specially
@@ -39,22 +40,39 @@ import platform
 import re
 import textwrap
 
-# This file is tailored to the NanoGUI documentation build system, the clang
-# module required is present in a full recursive clone here.
-base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
-clang_parent_folder = os.path.join(base_path, "ext/pybind11/tools/")
-if not os.path.isdir(clang_parent_folder):
-    raise RuntimeError(
-         "The NanoGUI dependencies repository (pybind11, etc.) appear to be missing!\n"
-         "You probably did not clone the project with --recursive. It is possible to recover\n"
-         "by calling 'git submodule update --init --recursive'"
-    )
-else:
-    sys.path.insert(0, clang_parent_folder)
+# CMake generated target is explicitly calling `python3`, this sanity check is
+# to support the fact that some `pip3` installable `clang` libraries are
+# packaged for python3, but only actually work in python2.
+if sys.version[0] != "3":
+    raise RuntimeError("`mkdoc_rst.py` must be run with Python3.")
 
-# Now we can import clang
-from clang import cindex
-from clang.cindex import CursorKind
+
+# If user has `clang` already installed, try and use that.  There are a couple
+# of unofficial options for python **3**, two that seem to work are `clang-5`
+# and `libclang-py3`.  It likely depends on what you have installed on your
+# system, so your mileage will very likely vary.
+try:
+    from clang import cindex
+    from clang.cindex import CursorKind
+except:
+    # Fallback on pybind11
+    # This file is tailored to the NanoGUI documentation build system, the clang
+    # module required is present in a full recursive clone here.
+    base_path = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+    clang_parent_folder = os.path.join(base_path, "ext/pybind11/tools/")
+    if not os.path.isdir(clang_parent_folder):
+        raise RuntimeError(
+             "The NanoGUI dependencies repository (pybind11, etc.) appear to be missing!\n"
+             "You probably did not clone the project with --recursive. It is possible to recover\n"
+             "by calling 'git submodule update --init --recursive'"
+        )
+    else:
+        sys.path.insert(0, clang_parent_folder)
+
+    # Now we can import clang
+    from clang import cindex
+    from clang.cindex import CursorKind
+
 from collections import OrderedDict
 from threading import Thread, Semaphore
 from multiprocessing import cpu_count
@@ -102,7 +120,14 @@ registered_names = dict()
 
 
 def d(s):
-    return s.decode('utf8')
+    if type(s) is bytes:
+        return s.decode('utf8')
+    elif type(s) is str:
+        return s
+    else:
+        raise RuntimeError(
+            "d(s): `s` cannot be decoded, it's type is: {0}".format(type(s))
+        )
 
 
 def sanitize_name(name):
@@ -158,6 +183,7 @@ def process_comment(comment):
     s = re.sub(r'\\endrst', r'```\n\n', s)
     s = re.sub(r'.. note::', r'Note:', s)
     s = re.sub(r'.. warning::', r'Warning:', s)
+    s = re.sub(r'.. danger::', r'Danger:', s)
     s = re.sub(r'.. code-block::\s*\w*', r'', s)
 
     s = re.sub(r'\\c\s+%s' % cpp_group, r'``\1``', s)
@@ -230,8 +256,11 @@ def process_comment(comment):
                     result += line.strip()
                 else:
                     # this is a .. code-block:: indentation (three spaces)
-                    if line.startswith('   ') and line[3] != ' ':
-                        result += line[3:].strip() + '\n'
+                    if line.startswith('   '):
+                        if line[3] != ' ': # outer-most indentation level
+                            result += line[3:].strip() + '\n'
+                        else:
+                            result += line[3:].rstrip() + '\n'
                     else:
                         result += line.strip() + '\n'
         else:

--- a/include/nanogui/glutil.h
+++ b/include/nanogui/glutil.h
@@ -449,24 +449,133 @@ public:
  * \struct Arcball glutil.h nanogui/glutil.h
  *
  * \brief Arcball helper class to interactively rotate objects on-screen.
+ *
+ * The Arcball class enables fluid interaction by representing rotations using
+ * a quaternion, and is setup to be used in conjunction with the existing
+ * mouse callbacks defined in \ref nanogui::Widget.  The Arcball operates by
+ * maintaining an "active" state which is typically controlled using a mouse
+ * button click / release.  A click pressed would call \ref Arcball::button
+ * with ``down = true``, and a click released with ``down = false``.  The high
+ * level mechanics are:
+ *
+ * 1. The Arcball is made active by calling \ref Arcball::button with a
+ *    specified click location, and ``down = true``.
+ * 2. As the user holds the mouse button down and drags, calls to
+ *    \ref Arcball::motion are issued.  Internally, the Arcball keeps track of
+ *    how far the rotation is from the start click.  During the active state,
+ *    \ref mQuat is not updated, call \ref Arcball::matrix to get the current
+ *    rotation for use in drawing updates.
+ * 3. The user releases the mouse button, and a call to \ref Arcball::button
+ *    with ``down = false``.  The Arcball is no longer active, and its internal
+ *    \ref mQuat is updated.
+ *
+ * A very simple \ref nanogui::Screen derived class to illustrate usage:
+ *
+ * \rst
+ * .. code-block:: cpp
+ *
+ *    class ArcballScreen : public nanogui::Screen {
+ *    public:
+ *        // Creating a 400x400 window
+ *        ArcballScreen() : nanogui::Screen({400, 400}, "ArcballDemo") {
+ *            mArcball.setSize(mSize);// Note 1
+ *        }
+ *
+ *        virtual bool mouseButtonEvent(const Vector2i &p, int button, bool down, int modifiers) override {
+ *            // In this example, we are using the left mouse button
+ *            // to control the arcball motion
+ *            if (button == GLFW_MOUSE_BUTTON_1) {
+ *                mArcball.button(p, down);// Note 2
+ *                return true;
+ *            }
+ *            return false;
+ *        }
+ *
+ *        virtual bool mouseMotionEvent(const Vector2i &p, const Vector2i &rel, int button, int modifiers) override {
+ *            if (button == GLFW_MOUSE_BUTTON_1) {
+ *                mArcball.motion(p);// Note 2
+ *                return true;
+ *            }
+ *            return false;
+ *        }
+ *
+ *        virtual void drawContents() override {
+ *            Matrix4f rotation = mArcball.matrix();
+ *            // ... do some drawing with the current rotation ...
+ *        }
+ *
+ *    protected:
+ *        nanogui::Arcball mArcball;
+ *    }
+ *
+ * **Note 1**
+ *     The user is responsible for setting the size with
+ *     :func:`Arcball::setSize <nanogui::Arcball::setSize>`, this does **not**
+ *     need to be the same as the Screen dimensions (e.g., you are using the
+ *     Arcball to control a specific ``glViewport``).
+ *
+ * **Note 2**
+ *     Be aware that the input vector ``p`` to
+ *     :func:`Widget::mouseButtonEvent <nanogui::Widget::mouseButtonEvent>`
+ *     and :func:`Widget::mouseMotionEvent <nanogui::Widget::mouseMotionEvent>`
+ *     are in the coordinates of the Screen dimensions (top left is ``(0, 0)``,
+ *     bottom right is ``(width, height)``).  If you are using the Arcball to
+ *     control a subregion of the Screen, you will want to transform the input
+ *     ``p`` before calling :func:`Arcball::button <nanogui::Arcball::button>`
+ *     or :func:`Arcball::motion <nanogui::Arcball::motion>`.  For example, if
+ *     controlling the right half of the screen, you might create
+ *     ``Vector2i adjusted_click(p.x() - (mSize.x() / 2), p.y())``.
+ * \endrst
  */
 struct Arcball {
+    /**
+     * \brief The default constructor.
+     *
+     * \rst
+     * .. note::
+     *
+     *    Make sure to call :func:`Arcball::setSize <nanogui::Arcball::setSize>`
+     *    after construction.
+     * \endrst
+     *
+     * \param speedFactor
+     *     The speed at which the Arcball rotates (default: ``2.0``).  See also
+     *     \ref mSpeedFactor.
+     */
     Arcball(float speedFactor = 2.0f)
         : mActive(false), mLastPos(Vector2i::Zero()), mSize(Vector2i::Zero()),
           mQuat(Quaternionf::Identity()),
           mIncr(Quaternionf::Identity()),
           mSpeedFactor(speedFactor) { }
 
+    /**
+     * Constructs an Arcball based off of the specified rotation.
+     *
+     * \rst
+     * .. note::
+     *
+     *    Make sure to call :func:`Arcball::setSize <nanogui::Arcball::setSize>`
+     *    after construction.
+     * \endrst
+     */
     Arcball(const Quaternionf &quat)
         : mActive(false), mLastPos(Vector2i::Zero()), mSize(Vector2i::Zero()),
           mQuat(quat),
           mIncr(Quaternionf::Identity()),
           mSpeedFactor(2.0f) { }
 
+    /**
+     * \brief The internal rotation of the Arcball.
+     *
+     * Call \ref Arcball::matrix for drawing loops, this method will not return
+     * any updates while \ref mActive is ``true``.
+     */
     Quaternionf &state() { return mQuat; }
 
+    /// ``const`` version of \ref Arcball::state.
     const Quaternionf &state() const { return mQuat; }
 
+    /// Sets the rotation of this Arcball.  The Arcball will be marked as **not** active.
     void setState(const Quaternionf &state) {
         mActive = false;
         mLastPos = Vector2i::Zero();
@@ -474,12 +583,38 @@ struct Arcball {
         mIncr = Quaternionf::Identity();
     }
 
+    /**
+     * \brief Sets the size of this Arcball.
+     *
+     * The size of the Arcball and the positions being provided in
+     * \ref Arcball::button and \ref Arcball::motion are directly related.
+     */
     void setSize(Vector2i size) { mSize = size; }
+
+    /// Returns the current size of this Arcball.
     const Vector2i &size() const { return mSize; }
+
+    /// Sets the speed at which this Arcball rotates.  See also \ref mSpeedFactor.
     void setSpeedFactor(float speedFactor) { mSpeedFactor = speedFactor; }
+
+    /// Returns the current speed at which this Arcball rotates.
     float speedFactor() const { return mSpeedFactor; }
+
+    /// Returns whether or not this Arcball is currently active.
     bool active() const { return mActive; }
 
+    /**
+     * \brief Signals a state change from active to non-active, or vice-versa.
+     *
+     * \param pos
+     *     The click location, should be in the same coordinate system as
+     *     specified by \ref mSize.
+     *
+     * \param pressed
+     *     When ``true``, this Arcball becomes active.  When ``false``, this
+     *     Arcball becomes non-active, and its internal \ref mQuat is updated
+     *     with the final rotation.
+     */
     void button(Vector2i pos, bool pressed) {
         mActive = pressed;
         mLastPos = pos;
@@ -488,11 +623,18 @@ struct Arcball {
         mIncr = Quaternionf::Identity();
     }
 
+    /**
+     * \brief When active, updates \ref mIncr corresponding to the specified
+     *        position.
+     *
+     * \param pos
+     *     Where the mouse has been dragged to.
+     */
     bool motion(Vector2i pos) {
         if (!mActive)
             return false;
 
-        /* Based on the rotation controller form AntTweakBar */
+        /* Based on the rotation controller from AntTweakBar */
         float invMinDim = 1.0f / mSize.minCoeff();
         float w = (float) mSize.x(), h = (float) mSize.y();
 
@@ -520,18 +662,57 @@ struct Arcball {
         return true;
     }
 
+    /**
+     * Returns the current rotation *including* the active motion, suitable for
+     * use with typical homogeneous matrix transformations.  The upper left 3x3
+     * block is the rotation matrix, with 0-0-0-1 as the right-most column /
+     * bottom row.
+     */
     Matrix4f matrix() const {
         Matrix4f result2 = Matrix4f::Identity();
         result2.block<3,3>(0, 0) = (mIncr * mQuat).toRotationMatrix();
         return result2;
     }
 
+    /**
+     * \brief Interrupts the current Arcball motion by calling
+     *        \ref Arcball::button with \ref mLastPos and ``false``.
+     *
+     * Use this method to "close" the state of the Arcball when a mouse release
+     * event is not available.  You would use this method if you need to stop
+     * the Arcball from updating its internal rotation, but the event stopping
+     * the rotation does **not** come from a mouse release.  For example, you
+     * have a callback that created a \ref nanogui::MessageDialog which will now
+     * be in focus.
+     */
+    void interrupt() { button(mLastPos, false); }
+
 protected:
+    /// Whether or not this Arcball is currently active.
     bool mActive;
+
+    /// The last click position (which triggered the Arcball to be active / non-active).
     Vector2i mLastPos;
+
+    /// The size of this Arcball.
     Vector2i mSize;
-    Quaternionf mQuat, mIncr;
+
+    /**
+     * The current stable state.  When this Arcball is active, represents the
+     * state of this Arcball when \ref Arcball::button was called with
+     * ``down = true``.
+     */
+    Quaternionf mQuat;
+
+    /// When active, tracks the overall update to the state.  Identity when non-active.
+    Quaternionf mIncr;
+
+    /**
+     * The speed at which this Arcball rotates.  Smaller values mean it rotates
+     * more slowly, higher values mean it rotates more quickly.
+     */
     float mSpeedFactor;
+
 public:
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 };

--- a/include/nanogui/glutil.h
+++ b/include/nanogui/glutil.h
@@ -537,7 +537,9 @@ public:
  *    \ref Arcball::motion are issued.  Internally, the Arcball keeps track of
  *    how far the rotation is from the start click.  During the active state,
  *    \ref mQuat is not updated, call \ref Arcball::matrix to get the current
- *    rotation for use in drawing updates.
+ *    rotation for use in drawing updates.  Receiving the rotation as a matrix
+ *    will usually be more convenient for traditional pipelines, however you
+ *    can also acquire the active rotation using \ref Arcball::activeState.
  * 3. The user releases the mouse button, and a call to \ref Arcball::button
  *    with ``down = false``.  The Arcball is no longer active, and its internal
  *    \ref mQuat is updated.
@@ -573,7 +575,10 @@ public:
  *        }
  *
  *        virtual void drawContents() override {
+ *            // Option 1: acquire a 4x4 homogeneous rotation matrix
  *            Matrix4f rotation = mArcball.matrix();
+ *            // Option 2: acquire an equivalent quaternion
+ *            Quaternionf rotation = mArcball.activeState();
  *            // ... do some drawing with the current rotation ...
  *        }
  *
@@ -748,9 +753,12 @@ struct Arcball {
         return result2;
     }
 
+    /// Returns the current rotation *including* the active motion.
+    Quaternionf activeState() const { return mIncr * mQuat; }
+
     /**
      * \brief Interrupts the current Arcball motion by calling
-     *        \ref Arcball::button with \ref mLastPos and ``false``.
+     *        \ref Arcball::button with ``(0, 0)`` and ``false``.
      *
      * Use this method to "close" the state of the Arcball when a mouse release
      * event is not available.  You would use this method if you need to stop
@@ -759,7 +767,7 @@ struct Arcball {
      * have a callback that created a \ref nanogui::MessageDialog which will now
      * be in focus.
      */
-    void interrupt() { button(mLastPos, false); }
+    void interrupt() { button(Vector2i::Zero(), false); }
 
 protected:
     /// Whether or not this Arcball is currently active.

--- a/python/glutil.cpp
+++ b/python/glutil.cpp
@@ -160,6 +160,7 @@ void register_glutil(py::module &m) {
         .def("button", &Arcball::button, py::arg("pos"), py::arg("pressed"), D(Arcball, button))
         .def("motion", &Arcball::motion, py::arg("pos"), D(Arcball, motion))
         .def("matrix", &Arcball::matrix, D(Arcball, matrix))
+        .def("activeState", &Arcball::activeState, D(Arcball, activeState))
         .def("interrupt", &Arcball::interrupt, D(Arcball, interrupt));
 
     m.def("project", &project, py::arg("obj"), py::arg("model"),

--- a/python/glutil.cpp
+++ b/python/glutil.cpp
@@ -135,7 +135,17 @@ void register_glutil(py::module &m) {
              D(GLShader, drawIndexed), py::arg("type"),
              py::arg("offset"), py::arg("count"))
         .def("setUniform", &setUniformPy, py::arg("name"),
-             py::arg("value"), py::arg("warn") = true);
+             py::arg("value"), py::arg("warn") = true)
+        .def("attribBuffer", &GLShader::attribBuffer, D(GLShader, attribBuffer));
+
+    py::class_<GLShader::Buffer>(m, "Buffer", D(GLShader, Buffer))
+        .def(py::init<>())
+        .def_readonly("id", &GLShader::Buffer::id, D(GLShader, Buffer, id))
+        .def_readonly("glType", &GLShader::Buffer::glType, D(GLShader, Buffer, glType))
+        .def_readonly("dim", &GLShader::Buffer::dim, D(GLShader, Buffer, dim))
+        .def_readonly("compSize", &GLShader::Buffer::compSize, D(GLShader, Buffer, compSize))
+        .def_readonly("size", &GLShader::Buffer::size, D(GLShader, Buffer, size))
+        .def_readonly("version", &GLShader::Buffer::version, D(GLShader, Buffer, version));
 
     py::class_<Arcball>(m, "Arcball", D(Arcball))
         .def(py::init<float>(), py::arg("speedFactor") = 2.f, D(Arcball, Arcball))

--- a/python/glutil.cpp
+++ b/python/glutil.cpp
@@ -149,7 +149,8 @@ void register_glutil(py::module &m) {
         .def("active", &Arcball::active, D(Arcball, active))
         .def("button", &Arcball::button, py::arg("pos"), py::arg("pressed"), D(Arcball, button))
         .def("motion", &Arcball::motion, py::arg("pos"), D(Arcball, motion))
-        .def("matrix", &Arcball::matrix, D(Arcball, matrix));
+        .def("matrix", &Arcball::matrix, D(Arcball, matrix))
+        .def("interrupt", &Arcball::interrupt, D(Arcball, interrupt));
 
     m.def("project", &project, py::arg("obj"), py::arg("model"),
           py::arg("proj"), py::arg("viewportSize"), D(project));

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -141,9 +141,11 @@ the mouse button down and drags, calls to Arcball::motion are issued.
 Internally, the Arcball keeps track of how far the rotation is from
 the start click. During the active state, mQuat is not updated, call
 Arcball::matrix to get the current rotation for use in drawing
-updates. 3. The user releases the mouse button, and a call to
-Arcball::button with ``down = false``. The Arcball is no longer
-active, and its internal mQuat is updated.
+updates. Receiving the rotation as a matrix will usually be more
+convenient for traditional pipelines, however you can also acquire the
+active rotation using Arcball::activeState. 3. The user releases the
+mouse button, and a call to Arcball::button with ``down = false``. The
+Arcball is no longer active, and its internal mQuat is updated.
 
 A very simple nanogui::Screen derived class to illustrate usage:
 
@@ -171,7 +173,10 @@ public:
         return false;
     }
     virtual void drawContents() override {
+        // Option 1: acquire a 4x4 homogeneous rotation matrix
         Matrix4f rotation = mArcball.matrix();
+        // Option 2: acquire an equivalent quaternion
+        Quaternionf rotation = mArcball.activeState();
         // ... do some drawing with the current rotation ...
     }
 protected:
@@ -223,6 +228,8 @@ after construction.
 
 static const char *__doc_nanogui_Arcball_active = R"doc(Returns whether or not this Arcball is currently active.)doc";
 
+static const char *__doc_nanogui_Arcball_activeState = R"doc(Returns the current rotation *including* the active motion.)doc";
+
 static const char *__doc_nanogui_Arcball_button =
 R"doc(Signals a state change from active to non-active, or vice-versa.
 
@@ -237,7 +244,7 @@ Parameter ``pressed``:
 
 static const char *__doc_nanogui_Arcball_interrupt =
 R"doc(Interrupts the current Arcball motion by calling Arcball::button with
-mLastPos and ``False``.
+``(0, 0)`` and ``False``.
 
 Use this method to "close" the state of the Arcball when a mouse
 release event is not available. You would use this method if you need

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -68,13 +68,13 @@ static const char *__doc_nanogui_AdvancedGridLayout_Anchor_Anchor_3 =
 R"doc(Create an Anchor at position ``(x, y)`` of size ``(w, h)`` with
 specified alignments.)doc";
 
-static const char *__doc_nanogui_AdvancedGridLayout_Anchor_align = R"doc(< The ``(x, y)`` Alignment.)doc";
+static const char *__doc_nanogui_AdvancedGridLayout_Anchor_align = R"doc(The ``(x, y)`` Alignment.)doc";
 
 static const char *__doc_nanogui_AdvancedGridLayout_Anchor_operator_int = R"doc(Allows for printing out Anchor position, size, and alignment.)doc";
 
-static const char *__doc_nanogui_AdvancedGridLayout_Anchor_pos = R"doc(< The ``(x, y)`` position.)doc";
+static const char *__doc_nanogui_AdvancedGridLayout_Anchor_pos = R"doc(The ``(x, y)`` position.)doc";
 
-static const char *__doc_nanogui_AdvancedGridLayout_Anchor_size = R"doc(< The ``(x, y)`` size.)doc";
+static const char *__doc_nanogui_AdvancedGridLayout_Anchor_size = R"doc(The ``(x, y)`` size.)doc";
 
 static const char *__doc_nanogui_AdvancedGridLayout_anchor = R"doc(Retrieve the anchor data structure for a given widget)doc";
 
@@ -116,13 +116,13 @@ static const char *__doc_nanogui_AdvancedGridLayout_setRowStretch = R"doc(Set th
 
 static const char *__doc_nanogui_Alignment = R"doc(The different kinds of alignments a layout can perform.)doc";
 
-static const char *__doc_nanogui_Alignment_Fill = R"doc(< Fill according to preferred sizes.)doc";
+static const char *__doc_nanogui_Alignment_Fill = R"doc(Fill according to preferred sizes.)doc";
 
-static const char *__doc_nanogui_Alignment_Maximum = R"doc(< Take as much space as is allowed.)doc";
+static const char *__doc_nanogui_Alignment_Maximum = R"doc(Take as much space as is allowed.)doc";
 
-static const char *__doc_nanogui_Alignment_Middle = R"doc(< Center align.)doc";
+static const char *__doc_nanogui_Alignment_Middle = R"doc(Center align.)doc";
 
-static const char *__doc_nanogui_Alignment_Minimum = R"doc(< Take only as much space as is required.)doc";
+static const char *__doc_nanogui_Alignment_Minimum = R"doc(Take only as much space as is required.)doc";
 
 static const char *__doc_nanogui_Arcball =
 R"doc(Arcball helper class to interactively rotate objects on-screen.
@@ -176,7 +176,7 @@ public:
     }
 protected:
     nanogui::Arcball mArcball;
-}
+};
 **Note 1**
  The user is responsible for setting the size with
  :func:`Arcball::setSize <nanogui::Arcball::setSize>`, this does **not**
@@ -192,7 +192,8 @@ protected:
  ``p`` before calling :func:`Arcball::button <nanogui::Arcball::button>`
  or :func:`Arcball::motion <nanogui::Arcball::motion>`.  For example, if
  controlling the right half of the screen, you might create
- ``Vector2i adjusted_click(p.x() - (mSize.x() / 2), p.y())``.
+ ``Vector2i adjusted_click(p.x() - (mSize.x() / 2), p.y())``, and then
+ call ``mArcball.motion(adjusted_click)``.
 
 ```)doc";
 
@@ -393,23 +394,23 @@ Parameter ``icon``:
 
 static const char *__doc_nanogui_Button_Flags = R"doc(Flags to specify the button behavior (can be combined with binary OR))doc";
 
-static const char *__doc_nanogui_Button_Flags_NormalButton = R"doc(< A normal Button.)doc";
+static const char *__doc_nanogui_Button_Flags_NormalButton = R"doc(A normal Button.)doc";
 
-static const char *__doc_nanogui_Button_Flags_PopupButton = R"doc(< A popup Button.)doc";
+static const char *__doc_nanogui_Button_Flags_PopupButton = R"doc(A popup Button.)doc";
 
-static const char *__doc_nanogui_Button_Flags_RadioButton = R"doc(< A radio Button.)doc";
+static const char *__doc_nanogui_Button_Flags_RadioButton = R"doc(A radio Button.)doc";
 
-static const char *__doc_nanogui_Button_Flags_ToggleButton = R"doc(< A toggle Button.)doc";
+static const char *__doc_nanogui_Button_Flags_ToggleButton = R"doc(A toggle Button.)doc";
 
 static const char *__doc_nanogui_Button_IconPosition = R"doc(The available icon positions.)doc";
 
-static const char *__doc_nanogui_Button_IconPosition_Left = R"doc(< Button icon on the far left.)doc";
+static const char *__doc_nanogui_Button_IconPosition_Left = R"doc(Button icon on the far left.)doc";
 
-static const char *__doc_nanogui_Button_IconPosition_LeftCentered = R"doc(< Button icon on the left, centered (depends on caption text length).)doc";
+static const char *__doc_nanogui_Button_IconPosition_LeftCentered = R"doc(Button icon on the left, centered (depends on caption text length).)doc";
 
-static const char *__doc_nanogui_Button_IconPosition_Right = R"doc(< Button icon on the far right.)doc";
+static const char *__doc_nanogui_Button_IconPosition_Right = R"doc(Button icon on the far right.)doc";
 
-static const char *__doc_nanogui_Button_IconPosition_RightCentered = R"doc(< Button icon on the right, centered (depends on caption text length).)doc";
+static const char *__doc_nanogui_Button_IconPosition_RightCentered = R"doc(Button icon on the right, centered (depends on caption text length).)doc";
 
 static const char *__doc_nanogui_Button_backgroundColor = R"doc(Returns the background color of this Button.)doc";
 
@@ -1072,21 +1073,21 @@ static const char *__doc_nanogui_Cursor =
 R"doc(Cursor shapes available to use in GLFW. Shape of actual cursor
 determined by Operating System.)doc";
 
-static const char *__doc_nanogui_Cursor_Arrow = R"doc(< The arrow cursor.)doc";
+static const char *__doc_nanogui_Cursor_Arrow = R"doc(The arrow cursor.)doc";
 
-static const char *__doc_nanogui_Cursor_Crosshair = R"doc(< The crosshair cursor.)doc";
+static const char *__doc_nanogui_Cursor_Crosshair = R"doc(The crosshair cursor.)doc";
 
 static const char *__doc_nanogui_Cursor_CursorCount =
-R"doc(< Not a cursor --- should always be last: enables a loop over the
-cursor types.)doc";
+R"doc(Not a cursor --- should always be last: enables a loop over the cursor
+types.)doc";
 
-static const char *__doc_nanogui_Cursor_HResize = R"doc(< The horizontal resize cursor.)doc";
+static const char *__doc_nanogui_Cursor_HResize = R"doc(The horizontal resize cursor.)doc";
 
-static const char *__doc_nanogui_Cursor_Hand = R"doc(< The hand cursor.)doc";
+static const char *__doc_nanogui_Cursor_Hand = R"doc(The hand cursor.)doc";
 
-static const char *__doc_nanogui_Cursor_IBeam = R"doc(< The I-beam cursor.)doc";
+static const char *__doc_nanogui_Cursor_IBeam = R"doc(The I-beam cursor.)doc";
 
-static const char *__doc_nanogui_Cursor_VResize = R"doc(< The vertical resize cursor.)doc";
+static const char *__doc_nanogui_Cursor_VResize = R"doc(The vertical resize cursor.)doc";
 
 static const char *__doc_nanogui_FloatBox =
 R"doc(A specialization of TextBox representing floating point values.
@@ -1409,19 +1410,20 @@ associated vertex and index buffers from Eigen matrices.)doc";
 
 static const char *__doc_nanogui_GLShader_Buffer =
 R"doc(A wrapper struct for maintaining various aspects of items being
-managed by OpenGL.)doc";
+managed by OpenGL. Buffers are created when GLShader::uploadAttrib is
+called.)doc";
 
-static const char *__doc_nanogui_GLShader_Buffer_compSize = R"doc()doc";
+static const char *__doc_nanogui_GLShader_Buffer_compSize = R"doc(The size (in bytes) of an individual element in this buffer.)doc";
 
-static const char *__doc_nanogui_GLShader_Buffer_dim = R"doc()doc";
+static const char *__doc_nanogui_GLShader_Buffer_dim = R"doc(The dimension of this buffer (typically the row width).)doc";
 
-static const char *__doc_nanogui_GLShader_Buffer_glType = R"doc()doc";
+static const char *__doc_nanogui_GLShader_Buffer_glType = R"doc(The OpenGL type of this buffer.)doc";
 
-static const char *__doc_nanogui_GLShader_Buffer_id = R"doc()doc";
+static const char *__doc_nanogui_GLShader_Buffer_id = R"doc(The identifier used with OpenGL.)doc";
 
-static const char *__doc_nanogui_GLShader_Buffer_size = R"doc()doc";
+static const char *__doc_nanogui_GLShader_Buffer_size = R"doc(The total number of elements represented by this buffer.)doc";
 
-static const char *__doc_nanogui_GLShader_Buffer_version = R"doc()doc";
+static const char *__doc_nanogui_GLShader_Buffer_version = R"doc(The current version if this buffer.)doc";
 
 static const char *__doc_nanogui_GLShader_GLShader = R"doc(Create an unitialized OpenGL shader)doc";
 
@@ -1429,13 +1431,52 @@ static const char *__doc_nanogui_GLShader_attrib =
 R"doc(Return the handle of a named shader attribute (-1 if it does not
 exist))doc";
 
+static const char *__doc_nanogui_GLShader_attribBuffer =
+R"doc((Advanced) Returns a reference to the specified GLShader::Buffer.
+
+```
+Danger:
+Extreme caution must be exercised when using this method.  The user is
+discouraged from explicitly storing the reference returned, as it can
+change, become deprecated, or no longer reside in
+:member:`mBufferObjects <nanogui::GLShader::mBufferObjects>`.
+There are generally very few use cases that justify using this method
+directly.  For example, if you need the version of a buffer, call
+:func:`attribVersion <nanogui::GLShader::attribVersion>`.  If you want
+to share data between :class:`GLShader <nanogui::GLShader>` objects,
+call :func:`shareAttrib <nanogui::GLShader::shareAttrib>`.
+One example use case for this method is sharing data between different
+GPU pipelines such as CUDA or OpenCL.  When sharing data, you
+typically need to map pointers between the API's.  The returned
+buffer's :member:`Buffer::id <nanogui::GLShader::Buffer::id>` is the
+``GLuint`` you will want to map to the other API.
+In short, only use this method if you absolutely need to.
+
+```
+
+Parameter ``name``:
+    The name of the desired attribute.
+
+Returns:
+    A reference to the current buffer associated with ``name``. Should
+    not be explicitly stored.
+
+Throws:
+    std::runtime_error If ``name`` is not found.)doc";
+
 static const char *__doc_nanogui_GLShader_attribVersion = R"doc(Return the version number of a given attribute)doc";
 
-static const char *__doc_nanogui_GLShader_bind = R"doc(Select this shader for subsequent draw calls)doc";
+static const char *__doc_nanogui_GLShader_bind =
+R"doc(Select this shader for subsequent draw calls. Simply executes
+``glUseProgram`` with mProgramShader, and ``glBindVertexArray`` with
+mVertexArrayObject.)doc";
 
 static const char *__doc_nanogui_GLShader_bufferSize = R"doc(Return the size of all registered buffers in bytes)doc";
 
-static const char *__doc_nanogui_GLShader_define = R"doc(Set a preprocessor definition)doc";
+static const char *__doc_nanogui_GLShader_define =
+R"doc(Set a preprocessor definition. Custom preprocessor definitions must be
+added **before** initializing the shader (e.g., via initFromFiles).
+See also: mDefinitions.)doc";
 
 static const char *__doc_nanogui_GLShader_downloadAttrib = R"doc(Download a vertex buffer object into an Eigen matrix)doc";
 
@@ -1487,21 +1528,39 @@ Parameter ``geometry_fname``:
 
 static const char *__doc_nanogui_GLShader_invalidateAttribs = R"doc(Invalidate the version numbers associated with attribute data)doc";
 
-static const char *__doc_nanogui_GLShader_mBufferObjects = R"doc()doc";
+static const char *__doc_nanogui_GLShader_mBufferObjects =
+R"doc(The map of string names to buffer objects representing the various
+attributes that have been uploaded using uploadAttrib.)doc";
 
-static const char *__doc_nanogui_GLShader_mDefinitions = R"doc()doc";
+static const char *__doc_nanogui_GLShader_mDefinitions =
+R"doc(```
+The map of preprocessor names to values (if any have been created).  If
+a definition was added seeking to create ``#define WIDTH 256``, the key
+would be ``"WIDTH"`` and the value would be ``"256"``.  These definitions
+will be included automatically in the string that gets compiled for the
+vertex, geometry, and fragment shader code.
 
-static const char *__doc_nanogui_GLShader_mFragmentShader = R"doc()doc";
+```)doc";
 
-static const char *__doc_nanogui_GLShader_mGeometryShader = R"doc()doc";
+static const char *__doc_nanogui_GLShader_mFragmentShader =
+R"doc(The fragment shader of this GLShader (as returned by
+``glCreateShader``).)doc";
 
-static const char *__doc_nanogui_GLShader_mName = R"doc()doc";
+static const char *__doc_nanogui_GLShader_mGeometryShader =
+R"doc(The geometry shader (if requested) of this GLShader (as returned by
+``glCreateShader``).)doc";
 
-static const char *__doc_nanogui_GLShader_mProgramShader = R"doc()doc";
+static const char *__doc_nanogui_GLShader_mName = R"doc(The registered name of this GLShader.)doc";
 
-static const char *__doc_nanogui_GLShader_mVertexArrayObject = R"doc()doc";
+static const char *__doc_nanogui_GLShader_mProgramShader = R"doc(The OpenGL program (as returned by ``glCreateProgram``).)doc";
 
-static const char *__doc_nanogui_GLShader_mVertexShader = R"doc()doc";
+static const char *__doc_nanogui_GLShader_mVertexArrayObject =
+R"doc(The vertex array associated with this GLShader (as returned by
+``glGenVertexArrays``).)doc";
+
+static const char *__doc_nanogui_GLShader_mVertexShader =
+R"doc(The vertex shader of this GLShader (as returned by
+``glCreateShader``).)doc";
 
 static const char *__doc_nanogui_GLShader_name = R"doc(Return the name of the shader)doc";
 
@@ -2265,9 +2324,9 @@ static const char *__doc_nanogui_Object_m_refCount = R"doc()doc";
 
 static const char *__doc_nanogui_Orientation = R"doc(The direction of data flow for a layout.)doc";
 
-static const char *__doc_nanogui_Orientation_Horizontal = R"doc(< Layout expands on horizontal axis.)doc";
+static const char *__doc_nanogui_Orientation_Horizontal = R"doc(Layout expands on horizontal axis.)doc";
 
-static const char *__doc_nanogui_Orientation_Vertical = R"doc(< Layout expands on vertical axis.)doc";
+static const char *__doc_nanogui_Orientation_Vertical = R"doc(Layout expands on vertical axis.)doc";
 
 static const char *__doc_nanogui_Popup =
 R"doc(Popup window for combo boxes, popup buttons, nested dialogs etc.

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -70,7 +70,7 @@ specified alignments.)doc";
 
 static const char *__doc_nanogui_AdvancedGridLayout_Anchor_align = R"doc(< The ``(x, y)`` Alignment.)doc";
 
-static const char *__doc_nanogui_AdvancedGridLayout_Anchor_operator_basic_string = R"doc(Allows for printing out Anchor position, size, and alignment.)doc";
+static const char *__doc_nanogui_AdvancedGridLayout_Anchor_operator_int = R"doc(Allows for printing out Anchor position, size, and alignment.)doc";
 
 static const char *__doc_nanogui_AdvancedGridLayout_Anchor_pos = R"doc(< The ``(x, y)`` position.)doc";
 
@@ -124,31 +124,159 @@ static const char *__doc_nanogui_Alignment_Middle = R"doc(< Center align.)doc";
 
 static const char *__doc_nanogui_Alignment_Minimum = R"doc(< Take only as much space as is required.)doc";
 
-static const char *__doc_nanogui_Arcball = R"doc(Arcball helper class to interactively rotate objects on-screen.)doc";
+static const char *__doc_nanogui_Arcball =
+R"doc(Arcball helper class to interactively rotate objects on-screen.
 
-static const char *__doc_nanogui_Arcball_Arcball = R"doc()doc";
+The Arcball class enables fluid interaction by representing rotations
+using a quaternion, and is setup to be used in conjunction with the
+existing mouse callbacks defined in nanogui::Widget. The Arcball
+operates by maintaining an "active" state which is typically
+controlled using a mouse button click / release. A click pressed would
+call Arcball::button with ``down = true``, and a click released with
+``down = false``. The high level mechanics are:
 
-static const char *__doc_nanogui_Arcball_Arcball_2 = R"doc()doc";
+1. The Arcball is made active by calling Arcball::button with a
+specified click location, and ``down = true``. 2. As the user holds
+the mouse button down and drags, calls to Arcball::motion are issued.
+Internally, the Arcball keeps track of how far the rotation is from
+the start click. During the active state, mQuat is not updated, call
+Arcball::matrix to get the current rotation for use in drawing
+updates. 3. The user releases the mouse button, and a call to
+Arcball::button with ``down = false``. The Arcball is no longer
+active, and its internal mQuat is updated.
 
-static const char *__doc_nanogui_Arcball_active = R"doc()doc";
+A very simple nanogui::Screen derived class to illustrate usage:
 
-static const char *__doc_nanogui_Arcball_button = R"doc()doc";
+```
+class ArcballScreen : public nanogui::Screen {
+public:
+    // Creating a 400x400 window
+    ArcballScreen() : nanogui::Screen({400, 400}, "ArcballDemo") {
+        mArcball.setSize(mSize);// Note 1
+    }
+    virtual bool mouseButtonEvent(const Vector2i &p, int button, bool down, int modifiers) override {
+        // In this example, we are using the left mouse button
+        // to control the arcball motion
+        if (button == GLFW_MOUSE_BUTTON_1) {
+            mArcball.button(p, down);// Note 2
+            return true;
+        }
+        return false;
+    }
+    virtual bool mouseMotionEvent(const Vector2i &p, const Vector2i &rel, int button, int modifiers) override {
+        if (button == GLFW_MOUSE_BUTTON_1) {
+            mArcball.motion(p);// Note 2
+            return true;
+        }
+        return false;
+    }
+    virtual void drawContents() override {
+        Matrix4f rotation = mArcball.matrix();
+        // ... do some drawing with the current rotation ...
+    }
+protected:
+    nanogui::Arcball mArcball;
+}
+**Note 1**
+ The user is responsible for setting the size with
+ :func:`Arcball::setSize <nanogui::Arcball::setSize>`, this does **not**
+ need to be the same as the Screen dimensions (e.g., you are using the
+ Arcball to control a specific ``glViewport``).
+**Note 2**
+ Be aware that the input vector ``p`` to
+ :func:`Widget::mouseButtonEvent <nanogui::Widget::mouseButtonEvent>`
+ and :func:`Widget::mouseMotionEvent <nanogui::Widget::mouseMotionEvent>`
+ are in the coordinates of the Screen dimensions (top left is ``(0, 0)``,
+ bottom right is ``(width, height)``).  If you are using the Arcball to
+ control a subregion of the Screen, you will want to transform the input
+ ``p`` before calling :func:`Arcball::button <nanogui::Arcball::button>`
+ or :func:`Arcball::motion <nanogui::Arcball::motion>`.  For example, if
+ controlling the right half of the screen, you might create
+ ``Vector2i adjusted_click(p.x() - (mSize.x() / 2), p.y())``.
 
-static const char *__doc_nanogui_Arcball_mActive = R"doc()doc";
+```)doc";
 
-static const char *__doc_nanogui_Arcball_mIncr = R"doc()doc";
+static const char *__doc_nanogui_Arcball_Arcball =
+R"doc(The default constructor.
 
-static const char *__doc_nanogui_Arcball_mLastPos = R"doc()doc";
+```
+Note:
+Make sure to call :func:`Arcball::setSize <nanogui::Arcball::setSize>`
+after construction.
 
-static const char *__doc_nanogui_Arcball_mQuat = R"doc()doc";
+```
 
-static const char *__doc_nanogui_Arcball_mSize = R"doc()doc";
+Parameter ``speedFactor``:
+    The speed at which the Arcball rotates (default: ``2.0``). See
+    also mSpeedFactor.)doc";
 
-static const char *__doc_nanogui_Arcball_mSpeedFactor = R"doc()doc";
+static const char *__doc_nanogui_Arcball_Arcball_2 =
+R"doc(Constructs an Arcball based off of the specified rotation.
 
-static const char *__doc_nanogui_Arcball_matrix = R"doc()doc";
+```
+Note:
+Make sure to call :func:`Arcball::setSize <nanogui::Arcball::setSize>`
+after construction.
 
-static const char *__doc_nanogui_Arcball_motion = R"doc()doc";
+```)doc";
+
+static const char *__doc_nanogui_Arcball_active = R"doc(Returns whether or not this Arcball is currently active.)doc";
+
+static const char *__doc_nanogui_Arcball_button =
+R"doc(Signals a state change from active to non-active, or vice-versa.
+
+Parameter ``pos``:
+    The click location, should be in the same coordinate system as
+    specified by mSize.
+
+Parameter ``pressed``:
+    When ``True``, this Arcball becomes active. When ``False``, this
+    Arcball becomes non-active, and its internal mQuat is updated with
+    the final rotation.)doc";
+
+static const char *__doc_nanogui_Arcball_interrupt =
+R"doc(Interrupts the current Arcball motion by calling Arcball::button with
+mLastPos and ``False``.
+
+Use this method to "close" the state of the Arcball when a mouse
+release event is not available. You would use this method if you need
+to stop the Arcball from updating its internal rotation, but the event
+stopping the rotation does **not** come from a mouse release. For
+example, you have a callback that created a nanogui::MessageDialog
+which will now be in focus.)doc";
+
+static const char *__doc_nanogui_Arcball_mActive = R"doc(Whether or not this Arcball is currently active.)doc";
+
+static const char *__doc_nanogui_Arcball_mIncr =
+R"doc(When active, tracks the overall update to the state. Identity when
+non-active.)doc";
+
+static const char *__doc_nanogui_Arcball_mLastPos =
+R"doc(The last click position (which triggered the Arcball to be active /
+non-active).)doc";
+
+static const char *__doc_nanogui_Arcball_mQuat =
+R"doc(The current stable state. When this Arcball is active, represents the
+state of this Arcball when Arcball::button was called with ``down =
+true``.)doc";
+
+static const char *__doc_nanogui_Arcball_mSize = R"doc(The size of this Arcball.)doc";
+
+static const char *__doc_nanogui_Arcball_mSpeedFactor =
+R"doc(The speed at which this Arcball rotates. Smaller values mean it
+rotates more slowly, higher values mean it rotates more quickly.)doc";
+
+static const char *__doc_nanogui_Arcball_matrix =
+R"doc(Returns the current rotation *including* the active motion, suitable
+for use with typical homogeneous matrix transformations. The upper
+left 3x3 block is the rotation matrix, with 0-0-0-1 as the right-most
+column / bottom row.)doc";
+
+static const char *__doc_nanogui_Arcball_motion =
+R"doc(When active, updates mIncr corresponding to the specified position.
+
+Parameter ``pos``:
+    Where the mouse has been dragged to.)doc";
 
 static const char *__doc_nanogui_Arcball_operator_delete = R"doc()doc";
 
@@ -174,17 +302,29 @@ static const char *__doc_nanogui_Arcball_operator_new_4 = R"doc()doc";
 
 static const char *__doc_nanogui_Arcball_operator_new_5 = R"doc()doc";
 
-static const char *__doc_nanogui_Arcball_setSize = R"doc()doc";
+static const char *__doc_nanogui_Arcball_setSize =
+R"doc(Sets the size of this Arcball.
 
-static const char *__doc_nanogui_Arcball_setSpeedFactor = R"doc()doc";
+The size of the Arcball and the positions being provided in
+Arcball::button and Arcball::motion are directly related.)doc";
 
-static const char *__doc_nanogui_Arcball_setState = R"doc()doc";
+static const char *__doc_nanogui_Arcball_setSpeedFactor = R"doc(Sets the speed at which this Arcball rotates. See also mSpeedFactor.)doc";
 
-static const char *__doc_nanogui_Arcball_size = R"doc()doc";
+static const char *__doc_nanogui_Arcball_setState =
+R"doc(Sets the rotation of this Arcball. The Arcball will be marked as
+**not** active.)doc";
 
-static const char *__doc_nanogui_Arcball_speedFactor = R"doc()doc";
+static const char *__doc_nanogui_Arcball_size = R"doc(Returns the current size of this Arcball.)doc";
 
-static const char *__doc_nanogui_Arcball_state = R"doc()doc";
+static const char *__doc_nanogui_Arcball_speedFactor = R"doc(Returns the current speed at which this Arcball rotates.)doc";
+
+static const char *__doc_nanogui_Arcball_state =
+R"doc(The internal rotation of the Arcball.
+
+Call Arcball::matrix for drawing loops, this method will not return
+any updates while mActive is ``True``.)doc";
+
+static const char *__doc_nanogui_Arcball_state_2 = R"doc(``const`` version of Arcball::state.)doc";
 
 static const char *__doc_nanogui_BoxLayout =
 R"doc(Simple horizontal/vertical box layout
@@ -1031,9 +1171,9 @@ h->addGroup("Group 1");
 h->addVariable("integer variable", aInt);
 // Expose a float variable via setter/getter functions
 h->addVariable(
-[&](float value) { aFloat = value; },
-[&]() { return *aFloat; },
-"float variable");
+  [&](float value) { aFloat = value; },
+  [&]() { return *aFloat; },
+  "float variable");
 // add a new button
 h->addButton("Button", [&]() { std::cout << "Button pressed" << std::endl; });
 
@@ -1148,8 +1288,8 @@ that rendered objects don't spill into neighboring widgets.
 
 ```
 **Usage**
-Override :func:`nanogui::GLCanvas::drawGL` in subclasses to provide
-custom drawing code.  See :ref:`nanogui_example_4`.
+ Override :func:`nanogui::GLCanvas::drawGL` in subclasses to provide
+ custom drawing code.  See :ref:`nanogui_example_4`.
 
 ```)doc";
 
@@ -3525,18 +3665,18 @@ Note:
 When using ``nvgFontSize`` for icons in subclasses, make sure to call
 the :func:`nanogui::Widget::icon_scale` function.  Expected usage when
 *drawing* icon fonts is something like:
-virtual void draw(NVGcontext *ctx) {
-// fontSize depends on the kind of Widget.  Search for `FontSize`
-// in the Theme class (e.g., standard vs button)
-float ih = fontSize;
-// assuming your Widget has a declared `mIcon`
-if (nvgIsFontIcon(mIcon)) {
-ih *= icon_scale();
-nvgFontFace(ctx, "icons");
-nvgFontSize(ctx, ih);
-/// remaining drawing code (see button.cpp for more)
-}
-}
+   virtual void draw(NVGcontext *ctx) {
+       // fontSize depends on the kind of Widget.  Search for `FontSize`
+       // in the Theme class (e.g., standard vs button)
+       float ih = fontSize;
+       // assuming your Widget has a declared `mIcon`
+       if (nvgIsFontIcon(mIcon)) {
+           ih *= icon_scale();
+           nvgFontFace(ctx, "icons");
+           nvgFontSize(ctx, ih);
+           /// remaining drawing code (see button.cpp for more)
+       }
+   }
 
 ```)doc";
 

--- a/src/glutil.cpp
+++ b/src/glutil.cpp
@@ -296,6 +296,15 @@ void GLShader::free() {
     glDeleteShader(mGeometryShader); mGeometryShader = 0;
 }
 
+const GLShader::Buffer &GLShader::attribBuffer(const std::string &name) {
+    for (auto &pair : mBufferObjects) {
+        if (pair.first == name)
+            return pair.second;
+    }
+
+    throw std::runtime_error(mName + ": attribBuffer: " + name + " not found!");
+}
+
 //  ----------------------------------------------------
 
 void GLUniformBuffer::init() {


### PR DESCRIPTION
Fixes #284.

### `Arcball`

- Docs completed, including brief example of how to coordinate it with a `nanogui::Screen`.
- Added `Arcball::interrupt`, which just calls `button(Vector2i::Zero(), false)` to close out state in absense of mouse click.
- Added the ability to gain the active rotation as a quaternion (`Quaterionf Arcball::activeState() const`).  Currently it can only be obtained with `Arcball::matrix`, which is nice for traditional model-view-projection creation.  Having access to the updated quaternion is useful for more efficient / convenient for direct `Vector3f` transformations.
- Associated python bindings / `py_doc.h` added.

### `GLShader`

- Docs completed.
- `GLShader::Buffer` is now a `public` nested type.
- Acquisition of e.g., `"position"` can be done with the new `const GLShader::Buffer & attribBuffer(const std::string &name) const`.
    - Throws `std::runtime_error` if not found.
    - Example usage for CUDA would be

        ```cpp
        // map the positions to write from CUDA
        const auto &position_buff = mPointShader.attribBuffer("position");
        GLuint gl_positions = position_buff.id;
        cudaGraphicsGLRegisterBuffer(
            &mPositionsCudaResource, gl_positions, cudaGraphicsRegisterFlagsWriteDiscard
        );
        ```
- `nanogui.Buffer` class and `nanogui.GLShader.attribBuffer` are bound, but honestly I don't know how useful they will be on the python side.

### Docs Fixes

- I had some really crazy issues with the `pybind11/tools/clang`, which resulted in large amounts of docs being deleted (exceptions or occasional segfault (?!)).
    - Almost certainly a local problem, but enabled users to e.g., `pip3 install clang-5` if they experience the same problem.
    - The majority of the changes in `docs/mkdoc_rst.py` are accommodating this.
        - Try and import first, then fallback on `pybind11` vendored copy.
        - Changed `d(s)` to enable using `clang-5`, theirs is returning strings which can't be decoded.
- Make sure `DOXYGEN_DOCUMENTATION_BUILD` is defined (via `CMakeLists.txt`) when executing `make mkdoc`.
