### PR TITLE
focusEvent when Screen (application) out of focus

### DIFF
--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -255,16 +255,28 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
        a window from a Retina-capable screen to a normal
        screen on Mac OS X */
     glfwSetFramebufferSizeCallback(mGLFWWindow,
-        [](GLFWwindow* w, int width, int height) {
+        [](GLFWwindow *w, int width, int height) {
             auto it = __nanogui_screens.find(w);
             if (it == __nanogui_screens.end())
                 return;
-            Screen* s = it->second;
+            Screen *s = it->second;
 
             if (!s->mProcessEvents)
                 return;
 
             s->resizeCallbackEvent(width, height);
+        }
+    );
+
+    // notify when the screen has lost focus (e.g. application switch)
+    glfwSetWindowFocusCallback(mGLFWWindow,
+        [](GLFWwindow *w, int focused) {
+            auto it = __nanogui_screens.find(w);
+            if (it == __nanogui_screens.end())
+                return;
+
+            Screen *s = it->second;
+            s->focusEvent(static_cast<bool>(focused));
         }
     );
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -276,7 +276,8 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
                 return;
 
             Screen *s = it->second;
-            s->focusEvent(static_cast<bool>(focused));
+            // focused: 0 when false, 1 when true
+            s->focusEvent(focused != 0);
         }
     );
 


### PR DESCRIPTION
The `Widget::focusEvent` handler was already in place, this just makes it so that the `Screen` gets notified in the case that the application goes out of focus.  See [glfw docs on input focus](http://www.glfw.org/docs/latest/window_guide.html#window_focus).  I don't think there are any gotchas in terms of the other widgets and their focus, it should be agnostic to this.

In one of my applications I was stealing the mouse after a key press, but without an event notifying the application itself is out of focus, if I alt+Tab away I still have no mouse!