### PR TITLE
fix TabWidget indexing, added TabWidget::tab(int)

### DIFF
--- a/include/nanogui/tabwidget.h
+++ b/include/nanogui/tabwidget.h
@@ -28,7 +28,7 @@ NAMESPACE_BEGIN(nanogui)
  */
 class NANOGUI_EXPORT TabWidget : public Widget {
 public:
-    TabWidget(Widget* parent);
+    TabWidget(Widget *parent);
 
     void setActiveTab(int tabIndex);
     int activeTab() const;
@@ -42,8 +42,8 @@ public:
     const std::function<void(int)> &callback() const { return mCallback; }
 
     /// Creates a new tab with the specified name and returns a pointer to the layer.
-    Widget* createTab(const std::string &label);
-    Widget* createTab(int index, const std::string &label);
+    Widget *createTab(const std::string &label);
+    Widget *createTab(int index, const std::string &label);
 
     /// Inserts a tab at the end of the tabs collection and associates it with the provided widget.
     void addTab(const std::string &label, Widget *tab);
@@ -84,8 +84,53 @@ public:
      */
     void ensureTabVisible(int index);
 
-    const Widget* tab(const std::string &label) const;
-    Widget* tab(const std::string &label);
+    /**
+     * \brief Returns a ``const`` pointer to the Widget associated with the
+     *        specified label.
+     *
+     * \param label
+     *     The label used to create the tab.
+     *
+     * \return
+     *     The Widget associated with this label, or ``nullptr`` if not found.
+     */
+    const Widget *tab(const std::string &label) const;
+
+    /**
+     * \brief Returns a pointer to the Widget associated with the specified label.
+     *
+     * \param label
+     *     The label used to create the tab.
+     *
+     * \return
+     *     The Widget associated with this label, or ``nullptr`` if not found.
+     */
+    Widget *tab(const std::string &label);
+
+    /**
+     * \brief Returns a ``const`` pointer to the Widget associated with the
+     *        specified index.
+     *
+     * \param index
+     *     The current index of the desired Widget.
+     *
+     * \return
+     *     The Widget at the specified index, or ``nullptr`` if ``index`` is not
+     *     a valid index.
+     */
+    const Widget *tab(int index) const;
+
+    /**
+     * \brief Returns a pointer to the Widget associated with the specified index.
+     *
+     * \param index
+     *     The current index of the desired Widget.
+     *
+     * \return
+     *     The Widget at the specified index, or ``nullptr`` if ``index`` is not
+     *     a valid index.
+     */
+    Widget *tab(int index);
 
     virtual void performLayout(NVGcontext* ctx) override;
     virtual Vector2i preferredSize(NVGcontext* ctx) const override;

--- a/python/tabs.cpp
+++ b/python/tabs.cpp
@@ -45,6 +45,7 @@ void register_tabs(py::module &m) {
         .def("tabLabelAt", &TabWidget::tabLabelAt, D(TabWidget, tabLabelAt))
         .def("tabIndex", &TabWidget::tabIndex, D(TabWidget, tabIndex))
         .def("tab", (Widget * (TabWidget::*)(const std::string &)) &TabWidget::tab, D(TabWidget, tab))
+        .def("tab", (Widget * (TabWidget::*)(int)) &TabWidget::tab, D(TabWidget, tab))
         .def("ensureTabVisible", &TabWidget::ensureTabVisible, D(TabWidget, ensureTabVisible));
 }
 

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -85,14 +85,26 @@ void TabWidget::ensureTabVisible(int index) {
 
 const Widget *TabWidget::tab(const std::string &tabName) const {
     int index = mHeader->tabIndex(tabName);
-    if (index == mContent->childCount())
+    if (index == -1 || index == mContent->childCount())
         return nullptr;
     return mContent->children()[index];
 }
 
 Widget *TabWidget::tab(const std::string &tabName) {
     int index = mHeader->tabIndex(tabName);
-    if (index == mContent->childCount())
+    if (index == -1 || index == mContent->childCount())
+        return nullptr;
+    return mContent->children()[index];
+}
+
+const Widget *TabWidget::tab(int index) const {
+    if (index < 0 || index >= mContent->childCount())
+        return nullptr;
+    return mContent->children()[index];
+}
+
+Widget *TabWidget::tab(int index) {
+    if (index < 0 || index >= mContent->childCount())
         return nullptr;
     return mContent->children()[index];
 }


### PR DESCRIPTION
Fixes #289.

1. In the event that the returned `index` is `-1`, original code was indexing `mContent->children()[-1]`, causing the mystery (and undefined) pointer return.
2. Added `const Widget *tab(int index) const` and `Widget *tab(int index)`.  These are useful if you already have the index from `TabWidget::tabLabelIndex(const std::string &label)`.
3. Bound `TabWidget::tab(int)` on the python side.
    - Did **not** update `py_doc.h`.

If desired, the (not so elegant) testing code:

```cpp
#include <nanogui/nanogui.h>
#include <iostream>

int main(int argc, const char **argv) {
    nanogui::init();


    {
        // standard setup, create screen / window
        using namespace nanogui;
        Screen *screen = new Screen({600, 600}, "TabWidget Testing");

        Window *window = new Window(screen, "TabWidget Testing");
        window->setFixedSize({400, 400});
        window->setLayout(new GroupLayout());

        // create a tab widget / add a tab with some dummy data
        TabWidget *tabWidget = new TabWidget(window);
        tabWidget->setFixedSize({400 - 30, 400 - 60});
        Widget *layer = tabWidget->createTab("First");
        layer->setLayout(new GroupLayout());
        new Label(layer, "First");
        new Button(layer, "second");
        new Label(layer, "Third");
        new Button(layer, "fourth");

        // !!!
        auto check_it = [tabWidget]() {
            std::string label = "Not Here";

            std::cout << "Checking label acquisition (no print = good):" << std::endl;
            Widget *should_not_exist = tabWidget->tab(label);
            if (should_not_exist) {
                std::cout << "  Tab Label Index: "
                          << tabWidget->tabLabelIndex(label)
                          << std::endl;
                std::cout << "  Widget Index:    "
                          << tabWidget->tabIndex(should_not_exist)
                          << std::endl;
            }

            std::cout << "Checking label acquisition (no print = bad):" << std::endl;
            label = "First";
            Widget *should_exist = tabWidget->tab(label);
            if (should_exist) {
                std::cout << "  Tab Label Index: "
                          << tabWidget->tabLabelIndex(label)
                          << std::endl;
                std::cout << "  Widget Index:    "
                          << tabWidget->tabIndex(should_exist)
                          << std::endl;
            }

            std::cout << "Checking index acquisition (no print = good):" << std::endl;
            int index = -1;
            should_not_exist = tabWidget->tab(index);
            if (should_not_exist) {
                std::cout << "  Tab Index:    "
                          << tabWidget->tabIndex(should_not_exist)
                          << std::endl;
                std::cout << "  Widget Index: "
                          << tabWidget->tabIndex(should_not_exist)
                          << std::endl;
            }
            index = 1;
            should_not_exist = tabWidget->tab(index);
            if (should_not_exist) {
                std::cout << "  Tab Index:    "
                          << tabWidget->tabIndex(should_not_exist)
                          << std::endl;
                std::cout << "  Widget Index: "
                          << tabWidget->tabIndex(should_not_exist)
                          << std::endl;
            }

            std::cout << "Checking index acquisition (no print = bad):" << std::endl;
            index = 0;
            should_exist = tabWidget->tab(index);
            if (should_exist) {
                std::cout << "  Tab Index:    "
                          << tabWidget->tabIndex(should_exist)
                          << std::endl;
                std::cout << "  Widget Index: "
                          << tabWidget->tabIndex(should_exist)
                          << std::endl;
            }

        };

        check_it();

        screen->setVisible(true);
        screen->performLayout();

        nanogui::mainloop();
    }

    nanogui::shutdown();
    return 0;
}
```