### PR TITLE
fix XCode build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,10 +341,30 @@ add_library(nanogui-obj OBJECT
   src/serializer.cpp
 )
 
-add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
-  $<TARGET_OBJECTS:nanogui-obj>
-  $<TARGET_OBJECTS:glfw_objects>
-)
+# XCode has a serious bug where the XCode project produces an invalid target
+# that will not get linked if it consists only of objects from object libraries,
+# it will not generate any products (executables, libraries). The only work
+# around is to add a dummy source file to the library definition. This is an
+# XCode, not a CMake bug. See: https://itk.org/Bug/view.php?id=14044
+if (CMAKE_GENERATOR STREQUAL Xcode)
+  set(XCODE_DUMMY ${CMAKE_CURRENT_BINARY_DIR}/xcode_dummy.cpp)
+  file(WRITE ${XCODE_DUMMY} "")
+  add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
+    ${XCODE_DUMMY}
+    $<TARGET_OBJECTS:nanogui-obj>
+    $<TARGET_OBJECTS:glfw_objects>
+  )
+
+  # XCode also fails at linking GLFW, so we exclude it.  Note that the actual
+  # component we need to build is 'glfw_objects', which is merged into the
+  # NanoGUI library itself.
+  set_target_properties(glfw PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+else()
+  add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
+    $<TARGET_OBJECTS:nanogui-obj>
+    $<TARGET_OBJECTS:glfw_objects>
+  )
+endif()
 
 if (NANOGUI_BUILD_SHARED)
   set_property(TARGET nanogui-obj PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
- Revives original solution proposed in #220
    - Thanks @AndySomogyi !!!
- Adds exclusion of GLFW library, XCode fails to link this.
    - @liminchen this should fix your [linking problems here](https://github.com/wjakob/nanogui/issues/267#issuecomment-360564228)

This worked for me on XCode 8, can other people test and make sure it works for them?  I was able to build everything and run the executables from the *terminal*, but I don't actually use XCode and couldn't figure out how to get a GLFW app to run from XCode (something about what the terminal is).

@dingzeyuli does this PR work for you?

To test:

```console
$ git clone --recursive https://github.com/svenevs/nanogui.git
$ cd nanogui
$ git checkout fix_xcode
$ mkdir build && cd build
$ cmake .. -G Xcode
```
