### PR TITLE
skip linking GLFW for all build systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,12 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw" "ext_build/glfw")
+# Two targets have now been defined: `glfw_objects`, which will be merged into
+# NanoGUI at the end, and `glfw`.  The `glfw` target is the library itself
+# (e.g., libglfw.so), but can be skipped as we do not need to link against it
+# (because we merge `glfw_objects` into NanoGUI).  This is required for XCode,
+# but preferable for all build systems (reduces build artifacts).
+set_target_properties(glfw PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
 
 # Python support: add NANOGUI_PYTHON flag to all targets
 if (NANOGUI_BUILD_PYTHON)
@@ -354,11 +360,6 @@ if (CMAKE_GENERATOR STREQUAL Xcode)
     $<TARGET_OBJECTS:nanogui-obj>
     $<TARGET_OBJECTS:glfw_objects>
   )
-
-  # XCode also fails at linking GLFW, so we exclude it.  Note that the actual
-  # component we need to build is 'glfw_objects', which is merged into the
-  # NanoGUI library itself.
-  set_target_properties(glfw PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
 else()
   add_library(nanogui ${NANOGUI_LIBRARY_TYPE}
     $<TARGET_OBJECTS:nanogui-obj>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,8 +77,8 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw" "ext_build/glfw")
 # Two targets have now been defined: `glfw_objects`, which will be merged into
 # NanoGUI at the end, and `glfw`.  The `glfw` target is the library itself
 # (e.g., libglfw.so), but can be skipped as we do not need to link against it
-# (because we merge `glfw_objects` into NanoGUI).  This is required for XCode,
-# but preferable for all build systems (reduces build artifacts).
+# (because we merge `glfw_objects` into NanoGUI).  Skipping is required for
+# XCode, but preferable for all build systems (reduces build artifacts).
 set_target_properties(glfw PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
 
 # Python support: add NANOGUI_PYTHON flag to all targets


### PR DESCRIPTION
Instead of skipping just for Xcode, skip for all.  See [discussion here](https://github.com/wjakob/nanogui/pull/304#issuecomment-361069171).

This is particularly nice for parent projects that set `CMAKE_*_OUTPUT_DIRECTORY`, as GLFW will no longer appear.  Worked on OSX (Xcode and Makefile) and Linux (Makefile).

Assuming the Appeveyor tests work on windows, it should be good!