### PR TITLE
prevent children from being added to TabWidget

### DIFF
--- a/include/nanogui/tabwidget.h
+++ b/include/nanogui/tabwidget.h
@@ -25,10 +25,55 @@ NAMESPACE_BEGIN(nanogui)
  *
  * \brief A wrapper around the widgets TabHeader and StackedWidget which hooks
  *        the two classes together.
+ *
+ * \rst
+ *
+ * .. warning::
+ *
+ *    Unlike other widgets, children may **not** be added *directly* to a
+ *    TabWidget.  For example, the following code will raise an exception:
+ *
+ *    .. code-block:: cpp
+ *
+ *       // `this` might be say a nanogui::Screen instance
+ *       Window *window = new Window(this, "Window Title");
+ *       TabWidget *tabWidget = window->add<TabWidget>();
+ *       // this label would be a direct child of tabWidget,
+ *       // which is forbidden, so an exception will be raised
+ *       new Label(tabWidget, "Some Label");
+ *
+ *    Instead, you are expected to be creating tabs and adding widgets to those.
+ *
+ *    .. code-block:: cpp
+ *
+ *       // `this` might be say a nanogui::Screen instance
+ *       Window *window = new Window(this, "Window Title");
+ *       TabWidget *tabWidget = window->add<TabWidget>();
+ *       // Create a tab first
+ *       auto *layer = tabWidget->createTab("Tab Name");
+ *       // Add children to the created tabs
+ *       layer->setLayout(new GroupLayout());
+ *       new Label(layer, "Some Label");
+ *
+ *    A slightly more involved example of creating a TabWidget can also be found
+ *    in :ref:`nanogui_example_1` (search for ``tabWidget`` in the file).
+ *
+ * \endrst
  */
 class NANOGUI_EXPORT TabWidget : public Widget {
 public:
     TabWidget(Widget *parent);
+
+    /**
+     * \brief Forcibly prevent mis-use of the class by throwing an exception.
+     *        Children are not to be added directly to the TabWidget, see
+     *        the class level documentation (\ref TabWidget) for an example.
+     *
+     * \throws std::runtime_error
+     *     An exception is always thrown, as children are not allowed to be
+     *     added directly to this Widget.
+     */
+    virtual void addChild(int index, Widget *widget) override;
 
     void setActiveTab(int tabIndex);
     int activeTab() const;

--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -24,12 +24,29 @@
 NAMESPACE_BEGIN(nanogui)
 
 TabWidget::TabWidget(Widget* parent)
-    : Widget(parent), mHeader(new TabHeader(this)), mContent(new StackedWidget(this)) {
+    : Widget(parent)
+    , mHeader(new TabHeader(nullptr)) // create using nullptr, add children below
+    , mContent(new StackedWidget(nullptr)) {
+
+    // since TabWidget::addChild is going to throw an exception to prevent
+    // mis-use of this class, add the child directly
+    Widget::addChild(childCount(), mHeader);
+    Widget::addChild(childCount(), mContent);
+
     mHeader->setCallback([this](int i) {
         mContent->setSelectedIndex(i);
         if (mCallback)
             mCallback(i);
     });
+}
+
+void TabWidget::addChild(int /*index*/, Widget * /*widget*/) {
+    // there may only be two children: mHeader and mContent, created in the constructor
+    throw std::runtime_error(
+        "TabWidget: do not add children directly to the TabWidget, create tabs "
+        "and add children to the tabs.  See TabWidget class documentation for "
+        "example usage."
+    );
 }
 
 void TabWidget::setActiveTab(int tabIndex) {


### PR DESCRIPTION
- An exception is always raised (rather than a floating point signal)
- Brief example in class level documentation

Fixes #303.  The approach here is mostly what is described by @Thorius [in this comment](https://github.com/wjakob/nanogui/issues/303#issuecomment-361759831), only overriding the `Widget::addChild(int, Widget*)` method instead.

Breakdown of how / why it works:

1. When constructing a widget with the parent specified, this is all that really happens:

    https://github.com/wjakob/nanogui/blob/f61c407ea4cb336aefcdd82202c6e09ff21b9e79/src/widget.cpp#L28-L29

    As such, when creating `mHeader` and `mContent`, we first explicitly orphan them by initializing with `nullptr`:

    ```cpp
    TabWidget::TabWidget(Widget* parent)
        : Widget(parent)
        , mHeader(new TabHeader(nullptr)) // create using nullptr, add children below
        , mContent(new StackedWidget(nullptr)) {
    ```

    and then deliberately call `Widget::addChild` in the constructor body

    ```cpp
    // since TabWidget::addChild is going to throw an exception to prevent
    // mis-use of this class, add the child directly
    Widget::addChild(childCount(), mHeader);
    Widget::addChild(childCount(), mContent);
    ```

    this means that `TabWidget::addChild` is not called, but theme setting / reference counting is still updated correctly.

2. An exception is always raised in `TabWidget::addChild`, signaling as early as possible that this should not be done (rather than deferring to `performLayout` as discussed in #303).  As a side-effect, if somebody does really need to modify `TabWidget` and add more children in some derived class, presumably they will see what is going on in the constructor and figure it out.

    A simple test is to apply this diff to `example1.cpp`, which will trigger the desired exception:

    ```diff
    --- a/src/example1.cpp
    +++ b/src/example1.cpp
    @@ -340,6 +340,8 @@ public:

             TabWidget* tabWidget = window->add<TabWidget>();

    +        new Label(tabWidget, "This causes an exception");
    +
             Widget* layer = tabWidget->createTab("Color Wheel");
             layer->setLayout(new GroupLayout());
    ```

I think this is the cleanest possible way of doing this, while still leaving the door open for people to derive `TabWidget` if they desire.  Attached for convenience are the rendered docs explaining how to use this:

![tab_docs](https://user-images.githubusercontent.com/5871461/35657525-bf470782-06b1-11e8-8206-5ca38e0ccb5d.jpeg)
