### PR TITLE
export Serializer, example5 on serialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,11 +421,13 @@ if(NANOGUI_BUILD_EXAMPLE)
   add_executable(example2      src/example2.cpp)
   add_executable(example3      src/example3.cpp)
   add_executable(example4      src/example4.cpp)
+  add_executable(example5      src/example5.cpp)
   add_executable(example_icons src/example_icons.cpp)
   target_link_libraries(example1      nanogui ${NANOGUI_EXTRA_LIBS})
   target_link_libraries(example2      nanogui ${NANOGUI_EXTRA_LIBS})
   target_link_libraries(example3      nanogui ${NANOGUI_EXTRA_LIBS})
   target_link_libraries(example4      nanogui ${NANOGUI_EXTRA_LIBS})
+  target_link_libraries(example5      nanogui ${NANOGUI_EXTRA_LIBS})
   target_link_libraries(example_icons nanogui ${NANOGUI_EXTRA_LIBS})
 
   # Copy icons for example application

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -60,6 +60,22 @@ arbitrary sequence of OpenGL commands into a NanoGUI widget.
 - `Example 4 in C++ <https://github.com/wjakob/nanogui/blob/master/src/example4.cpp>`_
 - `Example 4 in Python <https://github.com/wjakob/nanogui/blob/master/python/example4.py>`_
 
+.. _nanogui_example_5:
+
+Example 5
+----------------------------------------------------------------------------------------
+
+The fifth example program demonstrates the :class:`nanogui::Serializer` interface.  It
+serves as both an example of how to use "namespace" scoping with the serializer
+interface (via :func:`push <nanogui::Serializer::push>` and
+:func:`pop <nanogui::Serializer::pop>`), as well as a testing suite.  You will observe
+that some of the widgets do not serialize "correctly"; developers wishing to serialize
+a widget that does not work correctly are encouraged to use this example program to help
+test their new ``save`` and ``load`` methods and submit a pull request with the fixed
+saving and loading code.
+
+- `Example 5 in C++ <https://github.com/wjakob/nanogui/blob/master/src/example5.cpp>`_
+
 .. _nanogui_example_icons:
 
 Example Icons

--- a/include/nanogui/serializer/core.h
+++ b/include/nanogui/serializer/core.h
@@ -52,8 +52,19 @@ NAMESPACE_END(detail)
  * Note that this header file just provides the basics; the files
  * ``nanogui/serializer/opengl.h``, and ``nanogui/serializer/sparse.h`` must
  * be included to serialize the respective data types.
+ *
+ * \rst
+ * .. tip::
+ *
+ *    Refer to :ref:`nanogui_example_5` for possible usage of the Serializer
+ *    interface.  If trying to enable serialization of a custom widget, a good
+ *    starting place would be to look at the *implementation* of
+ *    :func:`Button::save <nanogui::Button::save>` and
+ *    :func:`Button::load <nanogui::Button::load>`.  The general theme: first
+ *    serialize the parent class, then serialize the derived class.
+ * \endrst
  */
-class Serializer {
+class NANOGUI_EXPORT Serializer {
 protected:
 // this friendship breaks the documentation
 #ifndef DOXYGEN_SHOULD_SKIP_THIS

--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -600,7 +600,7 @@ public:
         /* Draw 2 triangles starting at index 0 */
         mShader.drawIndexed(GL_TRIANGLES, 0, 2);
     }
-private:
+protected:
     nanogui::ProgressBar *mProgress;
     nanogui::GLShader mShader;
 
@@ -608,6 +608,8 @@ private:
     imagesDataType mImagesData;
     int mCurrentImage;
 };
+
+#if !defined(NANOGUI_EXAMPLE_5_BYPASS) // example5 includes this file directly
 
 int main(int /* argc */, char ** /* argv */) {
     try {
@@ -633,3 +635,5 @@ int main(int /* argc */, char ** /* argv */) {
 
     return 0;
 }
+
+#endif // NANOGUI_EXAMPLE_5_BYPASS

--- a/src/example5.cpp
+++ b/src/example5.cpp
@@ -1,0 +1,264 @@
+/*
+    src/example5.cpp -- example of how to use the same serializer to save the
+    state of many different widgets using the `push` and `pop` feature of
+    the Serializer class to create "namespaces" for each widget being saved.
+
+    NanoGUI was developed by Wenzel Jakob <wenzel.jakob@epfl.ch>.
+    The widget drawing code is based on the NanoVG demo application
+    by Mikko Mononen.
+
+    All rights reserved. Use of this source code is governed by a
+    BSD-style license that can be found in the LICENSE.txt file.
+*/
+
+// this define just makes it so when we include the example1.cpp file,
+// the `main` method is not included
+// tip: including source files is BAD PRACTICE!  this was done out of laziness,
+//      since example1 uses most widgets, we simply inherit that
+//      ExampleApplication and serialize that
+#define NANOGUI_EXAMPLE_5_BYPASS
+#include "example1.cpp"
+
+#include <nanogui/serializer/core.h>
+#include <nanogui/serializer/opengl.h> // unused in this example
+#include <nanogui/serializer/sparse.h> // unused in this example
+
+#include <map>
+
+/*
+ * NOTE: not everything appears to get saved / restored.  The image selected,
+ *       what the ComboBox has selected, etc.  Feel free to investigate and
+ *       submit a PR with fixes to the `load` / `save` methods for those classes.
+ */
+
+// ExampleApplication is what is defined in example 1
+class ExtendedExampleApplication : public ExampleApplication {
+public:
+    ExtendedExampleApplication() : ExampleApplication() {
+        /* At this point, all of the widgets we are going to save / load are
+         * now created (because the ExampleAppication from "example1.cpp" has
+         * finished).  This is slightly odd, but since Example 1 uses many
+         * of the possible widgets, it's also a good test.
+         *
+         * In your own code, you'll likely only need to serialize one or two
+         * widgets or a shader.  In this code, we're going to serialize every
+         * child widget, as well as show how you might approach serializing
+         * components of a shader.
+         */
+
+        // first add all direct descendants of this ExtendedExampleApplication
+        std::vector<nanogui::Widget*> all_kids;
+        for (auto *c : mChildren) {
+            all_kids.emplace_back(c);
+        }
+
+        unsigned idx = 0;
+        while (all_kids.size() > 0) {
+            // grab the next widget
+            auto *c = all_kids.back();
+            all_kids.pop_back();
+
+            // add it to the map; give each child a unique "namespace"
+            auto name = mSerialFilename + std::string("_child_") + std::to_string(idx++);
+            mSerialMap[name] = c;
+
+            // add all children of current child `c` one to the list of all_kids
+            for (auto *child : c->children()) {
+                all_kids.emplace_back(child);
+            }
+        }
+
+        // add some simple controls to load / save
+        auto window = new nanogui::Window(this, "Serialization");
+        window->setLayout(new nanogui::GroupLayout());
+
+        // example1 is 1024x768, putting this in bottom right corner
+        window->setPosition({700, 640});
+
+        auto b = new nanogui::Button(window, "Save Example 5 state now?");
+        b->setCallback([&]() {
+            nanogui::Serializer serializer(mSerialFilename, true);
+            for (const auto& x : mSerialMap) {
+                // x.first is the string name
+                serializer.push(x.first);
+                // x.second is the widget pointer
+                x.second->save(serializer);
+                serializer.pop();
+            }
+
+            /* The shader MVP is set in the draw loop using the time but in real
+             * code you would `mShader.downloadAttrib` to actually capture the
+             * state of something.
+             *
+             * Basically, if there is no `save` method of a given Widget, push a
+             * name onto the Serializer, and explicitly set things.  See the
+             * Serializer docs, set and get are template functions.
+             *
+             * Note that the same names you push / set here must be identical to
+             * what you use to get when loading from the Serializer.  In this
+             * example it is simple enough to just write it out manually, but
+             * in your own code you would want to create variables to hold the
+             * name you are pushing / setting / getting to avoid typos.
+             */
+            serializer.push("the_shader_time");
+            serializer.set<float>("glfwTime", (float) glfwGetTime());
+            serializer.pop();
+
+            atLeastOneSave = true;
+            new nanogui::MessageDialog(
+                this, nanogui::MessageDialog::Type::Information, "Saved!",
+                "Go make some changes e.g. check boxes or change colors.  Then load."
+            );
+
+        });
+
+        // add a button to load the state
+        b = new nanogui::Button(window, "Restore previous Example 5 state now?");
+        b->setCallback([&]() {
+            // make sure there is something to load
+            if (!atLeastOneSave) {
+                new nanogui::MessageDialog(
+                    this, nanogui::MessageDialog::Type::Information, "Oops!",
+                    "You have to save the state before it can be restored ;)"
+                );
+            }
+            else {
+                nanogui::Serializer serializer(mSerialFilename, false);
+                for (const auto& x : mSerialMap) {
+                    // x.first is the string name
+                    serializer.push(x.first);
+                    // x.second is the widget pointer
+                    x.second->load(serializer);
+                    serializer.pop();
+                }
+
+                // reset the time to alter the MVP of mShader based on what
+                // was stored previously
+                serializer.push("the_shader_time");
+                float t = 0.0f;
+                serializer.get<float>("glfwTime", t);
+                glfwSetTime(t);
+                serializer.pop();
+            }
+        });
+
+        /* NOTE: none of these are used explicitly in the drawing code, this is
+         * an internal test to ensure that the various kinds of uploads are
+         * working in GLShader, as they rely on some of the serialization types.
+         */
+        mSerialShader.init(
+            /* An identifying name */
+            "fake_shader",
+
+            /* Vertex shader */
+            "#version 330\n"
+
+            "uniform uint uint32_t_test    = 0u;\n"
+            "uniform int int32_t_test      = 0;\n"
+            "uniform uint uint16_t_test    = 0u;\n"
+            "uniform int int16_t_test      = 0;\n"
+            "uniform uint uint8_t_test     = 0u;\n"
+            "uniform int int8_t_test       = 0;\n"
+            "uniform float floating64_test = 0;\n"
+            "uniform float floating32_test = 0;\n"
+            "uniform float half_test       = 0;\n"
+
+            // NOTE: adding all the `if` to force glsl not to optimize out!
+            "void main() {\n"
+            "    if (uint32_t_test > uint(1))\n"
+            "        gl_Position = vec4(0, 0, 0, 1);\n"
+            "    else if (int32_t_test > int(1))\n"
+            "        gl_Position = vec4(0.1, 0.1, 0.1, 1);\n"
+            "    else if (uint16_t_test > uint(1))\n"
+            "        gl_Position = vec4(0.2, 0.2, 0.2, 1);\n"
+            "    else if (int16_t_test > int(1))\n"
+            "        gl_Position = vec4(0.3, 0.3, 0.3, 1);\n"
+            "    else if (uint8_t_test > uint(1))\n"
+            "        gl_Position = vec4(0.4, 0.4, 0.4, 1);\n"
+            "    else if (int8_t_test > int(1))\n"
+            "        gl_Position = vec4(0.5, 0.5, 0.5, 1);\n"
+            "    else if (floating64_test > float(1))\n"
+            "        gl_Position = vec4(0.6, 0.6, 0.6, 1);\n"
+            "    else if (floating32_test > float(1))\n"
+            "        gl_Position = vec4(0.7, 0.7, 0.7, 1);\n"
+            "    else if (half_test > float(1))\n"
+            "        gl_Position = vec4(0.8, 0.8, 0.8, 1);\n"
+            "    else\n"
+            "        gl_Position = vec4(0);\n"
+            "}",
+
+            /* Fragment shader */
+            "#version 330\n"
+            "out vec4 color;\n"
+            "void main() {\n"
+            "    color = vec4(0.0, 0.0, 0.0, 1.0);\n"
+            "}"
+        );
+
+        mSerialShader.bind();
+        // upload uniforms, downloading is non-trivial and so is avoided.
+        // this tests the internal serialization structs just by compiling
+        mSerialShader.setUniform<uint32_t>("uint32_t_test", (uint32_t) 2);
+        mSerialShader.setUniform<int32_t>("int32_t_test",   (int32_t) -2);
+        mSerialShader.setUniform<uint16_t>("uint16_t_test", (uint16_t) 3);
+        mSerialShader.setUniform<int16_t>("int16_t_test",   (int16_t) -3);
+        mSerialShader.setUniform<uint8_t>("uint8_t_test",    (uint8_t) 4);
+        mSerialShader.setUniform<int8_t>("int8_t_test",      (int8_t) -4);
+        mSerialShader.setUniform<double>("floating64_test",   (double) 5);
+        mSerialShader.setUniform<float>("floating32_test",     (float) 6);
+        // vvv does not compile, incomplete type
+        // mSerialShader.setUniform<half_float::half>("half_test",  7);
+
+        this->performLayout();
+    }
+
+    ~ExtendedExampleApplication() { mSerialShader.free(); }
+
+protected:
+    /* Map of names to widgets.  We're going to save each widget in their own
+     * "namespace" in the serializer so that everything is saved rather than
+     * potentially overwriting some things.
+     */
+    std::map<std::string, nanogui::Widget*> mSerialMap;
+
+    /* This example will continuously overwrite the same file, in your own code
+     * you'll probably want to create new files or something if you want to
+     * be able to save and load multiple different snapshots.
+     */
+    std::string mSerialFilename = "nanogui_example_5_serialized";
+
+    /* Since we're using the same file each time, make sure that we've saved at
+     * least once before loading.
+     */
+    bool atLeastOneSave = false;
+
+    // Serialization shader test, does nothing
+    nanogui::GLShader mSerialShader;
+};
+
+// same as example1 loop, only uses `ExtendedExampleApplication`
+int main(void) {
+    try {
+        nanogui::init();
+
+        /* scoped variables */ {
+            nanogui::ref<ExtendedExampleApplication> app = new ExtendedExampleApplication();
+            app->drawAll();
+            app->setVisible(true);
+            nanogui::mainloop();
+        }
+
+        nanogui::shutdown();
+    }
+    catch (const std::runtime_error &e) {
+        std::string error_msg = std::string("Caught a fatal error: ") + std::string(e.what());
+        #if defined(_WIN32)
+            MessageBoxA(nullptr, error_msg.c_str(), NULL, MB_ICONERROR | MB_OK);
+        #else
+            std::cerr << error_msg << endl;
+        #endif
+        return 1;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Supercedes #261.

> I suspect that all of the LTO-related issues are simply due to the fact that the class declaration of the serializer reads
> 
> ```cpp
> class Serializer {
> ```
> and not
>
> ```cpp
> class NANOGUI_EXPORT Serializer {
> ```

**WOW** I can't believe how easy that should have been.  This PR just adds the `NANOGUI_EXPORT`, some `Serializer` docs, and `example5.cpp`.  It does **not** fix serialization of Themes (#210) completely, as serializing themes is actually much more convoluted.  I'll add some thoughts on it on that thread.  This PR also omits the changes to `glutil.h` from the other one, I'll fix those at a later time (I found the docs bug, just need to fix it).
