### PR TITLE
Fix TDM-GCC build

### DIFF
--- a/ext/glad/include/glad/glad.h
+++ b/ext/glad/include/glad/glad.h
@@ -27,7 +27,7 @@
 
 #if !defined(APIENTRY)
 #  if defined(_WIN32)
-#    define APIENTRY _stdcall
+#    define APIENTRY __stdcall
 #  else
 #    define APIENTRY
 #  endif

--- a/src/glutil.cpp
+++ b/src/glutil.cpp
@@ -10,6 +10,11 @@
 */
 
 #include <nanogui/glutil.h>
+#if defined(WIN32)
+#if !defined(__clang__)
+#include <malloc.h>
+#endif  // !defined(__clang__)
+#endif  // defined(WIN32)
 #include <iostream>
 #include <fstream>
 #include <Eigen/Geometry>


### PR DESCRIPTION
- Replace _stdcall with __stdcall keyword.
- Included required header for use of alloca function.
- Added dynamic loading mechanism for MonitorFromWindow function.