### PR TITLE
accommodate CMake policy CMP0048

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,10 @@
 cmake_minimum_required (VERSION 2.8.12)
 
+if (POLICY CMP0048)
+  # cmake warns if loaded from a min-3.0-required parent dir, so silence the warning:
+  cmake_policy(SET CMP0048 NEW)
+endif()
+
 project("NanoGUI")
 
 if (POLICY CMP0058)


### PR DESCRIPTION
When parent projects declare `project(... VERSION X.Y.Z)` this warning surfaces, same fix as [pybind11/#567](https://github.com/pybind/pybind11/issues/567).