### PR TITLE
 focus path on removed widgets gets set to parent

### DIFF
--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -139,7 +139,13 @@ public:
     /// Convenience function which appends a widget at the end
     void addChild(Widget *widget);
 
-    /// Remove a child widget by index
+    /**
+     * \brief Remove a child widget by index.
+     *
+     * \param index
+     *     The index into ``mChildren`` to remove.  If ``index < 0`` or
+     *     ``index >= mChildren.size()``, no will be action performed.
+     */
     void removeChild(int index);
 
     /// Remove a child widget by value

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -152,14 +152,18 @@ void Widget::addChild(Widget * widget) {
 }
 
 void Widget::removeChild(const Widget *widget) {
-    mChildren.erase(std::remove(mChildren.begin(), mChildren.end(), widget), mChildren.end());
-    widget->decRef();
+    if (widget) {
+        // ensure focus path does not retain removed widget
+        if (widget->focused())
+            this->requestFocus();
+        mChildren.erase(std::remove(mChildren.begin(), mChildren.end(), widget), mChildren.end());
+        widget->decRef();
+    }
 }
 
 void Widget::removeChild(int index) {
-    Widget *widget = mChildren[index];
-    mChildren.erase(mChildren.begin() + index);
-    widget->decRef();
+    if (index >= 0 && static_cast<size_t>(index) < mChildren.size())
+        removeChild(mChildren[index]);
 }
 
 int Widget::childIndex(Widget *widget) const {


### PR DESCRIPTION
Fixes #331.

- Focus path on deleted widget will cause segfault
- Better safety on `removeChild(int)` to prevent internal crashes when invalid index specified

@jzrake can you test this and confirm?  I just locally replaced the contents of `src/example2.cpp` with

```cpp
#include <nanogui/nanogui.h>

// set to 1 to test removeChild(0)
#define TEST_INDEX 0

using namespace nanogui;
class TestApp : public nanogui::Screen {
public:
    TestApp() : nanogui::Screen(Vector2i(400, 400), "") {
        auto b = new Button(this, "Click to remove");
        #if TEST_INDEX
            b->setCallback([this]() { this->removeChild(0); });
        #else
            b->setCallback([this, b]() { this->removeChild(b); });
        #endif
        performLayout();
    }
};

int main() {
    nanogui::init();
    {
        auto *t = new TestApp();
        t->performLayout();
        t->setVisible(true);
        nanogui::mainloop();
    }
    nanogui::shutdown();
    return 0;
}
```

@wjakob I'm a little concerned that `this->setFocused(true)` did not work, but `this->requestFocus()` did.  The real problem is that the deleted widget remains the one in focus, so the next click causes the segfault.

P.S. Breathe seems to have made a regression as far as the rendered signatures in the docs are concerned.  `\ref mChildren` did not work, nor did `\ref Widget::mChildren` nor `\ref nanogui::Widget::mChildren`.  They also changed their render signatures to include `nanogui::Widget` before everything which is really ugly.  I'm going to investigate this and hopefully find a fix.