### PR TITLE
Gl version detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,11 +23,12 @@ else()
   set(NANOGUI_USE_GLAD_DEFAULT OFF)
 endif()
 
-option(NANOGUI_BUILD_EXAMPLE "Build NanoGUI example application?" ON)
-option(NANOGUI_BUILD_SHARED  "Build NanoGUI as a shared library?" ON)
-option(NANOGUI_BUILD_PYTHON  "Build a Python plugin for NanoGUI?" ON)
-option(NANOGUI_USE_GLAD      "Use Glad OpenGL loader library?" ${NANOGUI_USE_GLAD_DEFAULT})
-option(NANOGUI_INSTALL       "Install NanoGUI on `make install`?" ON)
+option(NANOGUI_BUILD_EXAMPLE         "Build NanoGUI example application?" ON)
+option(NANOGUI_BUILD_SHARED          "Build NanoGUI as a shared library?" ON)
+option(NANOGUI_BUILD_PYTHON          "Build a Python plugin for NanoGUI?" ON)
+option(NANOGUI_USE_GLAD              "Use Glad OpenGL loader library?" ${NANOGUI_USE_GLAD_DEFAULT})
+option(NANOGUI_INSTALL               "Install NanoGUI on `make install`?" ON)
+option(NANOGUI_DEFAULT_GL_VERSION    "Default to GL3 compatability?"      ON)
 
 set(NANOGUI_PYTHON_VERSION "" CACHE STRING "Python version to use for compiling the Python plugin")
 
@@ -85,6 +86,11 @@ add_subdirectory("${CMAKE_CURRENT_SOURCE_DIR}/ext/glfw" "ext_build/glfw")
 # (because we merge `glfw_objects` into NanoGUI).  Skipping is required for
 # XCode, but preferable for all build systems (reduces build artifacts).
 set_target_properties(glfw PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+
+# GL Version support: add NANOVG_GL3_IMPLEMENTATION unless disabled
+if (NANOGUI_DEFAULT_GL_VERSION)
+  list(APPEND NANOGUI_EXTRA_DEFS -DNANOVG_GL3_IMPLEMENTATION)
+endif()
 
 # Python support: add NANOGUI_PYTHON flag to all targets
 if (NANOGUI_BUILD_PYTHON)

--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -16,6 +16,10 @@
 
 #include <nanogui/widget.h>
 
+#if defined(NANOVG_GL2_IMPLEMENTATION) || defined(NANOVG_GLES2_IMPLEMENTATION)
+#define NANOGUI_CURSOR_DISABLED
+#endif
+
 NAMESPACE_BEGIN(nanogui)
 
 /**
@@ -187,8 +191,10 @@ public:
 protected:
     GLFWwindow *mGLFWWindow;
     NVGcontext *mNVGContext;
+#if !defined(NANOGUI_CURSOR_DISABLED)
     GLFWcursor *mCursors[(int) Cursor::CursorCount];
     Cursor mCursor;
+#endif
     std::vector<Widget *> mFocusPath;
     Vector2i mFBSize;
     float mPixelRatio;

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -78,10 +78,8 @@ void mainloop(int refresh) {
                 std::chrono::milliseconds time(refresh);
                 while (mainloop_active) {
                     std::this_thread::sleep_for(time);
-#ifndef NANOVG_GLES2_IMPLEMENTATION
-#ifndef NANOVG_GL2_IMPLEMENTATION
+#if !defined(NANOVG_GL2_IMPLEMENTATION) && !defined(NANOVG_GLES2_IMPLEMENTATION)
                     glfwPostEmptyEvent();
-#endif
 #endif
                 }
             }

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -78,7 +78,11 @@ void mainloop(int refresh) {
                 std::chrono::milliseconds time(refresh);
                 while (mainloop_active) {
                     std::this_thread::sleep_for(time);
+#ifndef NANOVG_GLES2_IMPLEMENTATION
+#ifndef NANOVG_GL2_IMPLEMENTATION
                     glfwPostEmptyEvent();
+#endif
+#endif
                 }
             }
         );

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -31,13 +31,7 @@
 #  include <GLFW/glfw3native.h>
 #endif
 
-/* Allow enforcing the GL2 implementation of NanoVG */
-//#define NANOVG_GL3_IMPLEMENTATION
 #include <nanovg_gl.h>
-
-#if defined(NANOVG_GL2_IMPLEMENTATION) || defined(NANOVG_GLES2_IMPLEMENTATION)
-#define NANOVG_CURSOR_DISABLED
-#endif
 
 NAMESPACE_BEGIN(nanogui)
 
@@ -145,12 +139,12 @@ static float get_pixel_ratio(GLFWwindow *window) {
 
 Screen::Screen()
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
-#ifndef NANOVG_CURSOR_DISABLED
+#if !defined(NANOGUI_CURSOR_DISABLED)
       mCursor(Cursor::Arrow),
 #endif
       mBackground(0.3f, 0.3f, 0.32f, 1.f),
       mShutdownGLFWOnDestruct(false), mFullscreen(false) {
-#ifndef NANOVG_CURSOR_DISABLED
+#if !defined(NANOGUI_CURSOR_DISABLED)
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
 #endif
 }
@@ -160,12 +154,12 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
                int stencilBits, int nSamples,
                unsigned int glMajor, unsigned int glMinor)
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
-#ifndef NANOVG_CURSOR_DISABLED
+#if !defined(NANOGUI_CURSOR_DISABLED)
       mCursor(Cursor::Arrow),
 #endif
       mBackground(0.3f, 0.3f, 0.32f, 1.f), mCaption(caption),
       mShutdownGLFWOnDestruct(false), mFullscreen(fullscreen) {
-#ifndef NANOVG_CURSOR_DISABLED
+#if !defined(NANOGUI_CURSOR_DISABLED)
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
 #endif
 
@@ -277,8 +271,7 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
         }
     );
 
-#ifndef NANOVG_GL2_IMPLEMENTATION
-#ifndef NANOVG_GLES2_IMPLEMENTATION
+#if !defined(NANOVG_GL2_IMPLEMENTATION) && !defined(NANOVG_GLES2_IMPLEMENTATION)
     glfwSetDropCallback(mGLFWWindow,
         [](GLFWwindow *w, int count, const char **filenames) {
             auto it = __nanogui_screens.find(w);
@@ -290,7 +283,6 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
             s->dropCallbackEvent(count, filenames);
         }
     );
-#endif
 #endif
 
     glfwSetScrollCallback(mGLFWWindow,
@@ -389,7 +381,7 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
     mProcessEvents = true;
     __nanogui_screens[mGLFWWindow] = this;
 
-#ifndef NANOVG_CURSOR_DISABLED
+#if !defined(NANOGUI_CURSOR_DISABLED)
     for (int i=0; i < (int) Cursor::CursorCount; ++i)
         mCursors[i] = glfwCreateStandardCursor(GLFW_ARROW_CURSOR + i);
 #endif
@@ -401,7 +393,7 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
 
 Screen::~Screen() {
     __nanogui_screens.erase(mGLFWWindow);
-#ifndef NANOVG_CURSOR_DISABLED
+#if !defined(NANOGUI_CURSOR_DISABLED)
     for (int i=0; i < (int) Cursor::CursorCount; ++i) {
         if (mCursors[i])
             glfwDestroyCursor(mCursors[i]);
@@ -470,10 +462,8 @@ void Screen::drawWidgets() {
 #endif
 
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
-#ifndef NANOVG_GL2_IMPLEMENTATION
-#ifndef NANOVG_GLES2_IMPLEMENTATION
+#if !defined(NANOVG_GL2_IMPLEMENTATION) && !defined(NANOVG_GLES2_IMPLEMENTATION)
     glBindSampler(0, 0);
-#endif
 #endif
     nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
 
@@ -570,7 +560,7 @@ bool Screen::cursorPosCallbackEvent(double x, double y) {
         p -= Vector2i(1, 2);
 
         if (!mDragActive) {
-#ifndef NANOVG_CURSOR_DISABLED
+#if !defined(NANOGUI_CURSOR_DISABLED)
             Widget *widget = findWidget(p);
             if (widget != nullptr && widget->cursor() != mCursor) {
                 mCursor = widget->cursor();
@@ -620,7 +610,7 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
                 mMousePos - mDragWidget->parent()->absolutePosition(), button,
                 false, mModifiers);
 
-#ifndef NANOVG_CURSOR_DISABLED
+#if !defined(NANOGUI_CURSOR_DISABLED)
         if (dropWidget != nullptr && dropWidget->cursor() != mCursor) {
             mCursor = dropWidget->cursor();
             glfwSetCursor(mGLFWWindow, mCursors[(int) mCursor]);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -32,7 +32,7 @@
 #endif
 
 /* Allow enforcing the GL2 implementation of NanoVG */
-#define NANOVG_GL3_IMPLEMENTATION
+//#define NANOVG_GL3_IMPLEMENTATION
 #include <nanovg_gl.h>
 
 NAMESPACE_BEGIN(nanogui)

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -42,24 +42,24 @@ static bool gladInitialized = false;
 #endif
 
 inline NVGcontext* nvgCreateContext(int flags) {
-#if defined NANOVG_GL2_IMPLEMENTATION
+#if defined(NANOVG_GL2_IMPLEMENTATION)
   return nvgCreateGL2(flags);
-#elif defined NANOVG_GL3_IMPLEMENTATION
+#elif defined(NANOVG_GL3_IMPLEMENTATION)
   return nvgCreateGL3(flags);
-#elif defined NANOVG_GLES2_IMPLEMENTATION
+#elif defined(NANOVG_GLES2_IMPLEMENTATION)
   return nvgCreateGLES2(flags);
-#elif defined NANOVG_GLES3_IMPLEMENTATION
+#elif defined(NANOVG_GLES3_IMPLEMENTATION)
   return nvgCreateGLES3(flags);
 #endif
 }
 inline void nvgDeleteContext(NVGcontext* ctx) {
-#if defined NANOVG_GL2_IMPLEMENTATION
+#if defined(NANOVG_GL2_IMPLEMENTATION)
   nvgDeleteGL2(ctx);
-#elif defined NANOVG_GL3_IMPLEMENTATION
+#elif defined(NANOVG_GL3_IMPLEMENTATION)
   nvgDeleteGL3(ctx);
-#elif defined NANOVG_GLES2_IMPLEMENTATION
+#elif defined(NANOVG_GLES2_IMPLEMENTATION)
   nvgDeleteGLES2(ctx);
-#elif defined NANOVG_GLES3_IMPLEMENTATION
+#elif defined(NANOVG_GLES3_IMPLEMENTATION)
   nvgDeleteGLES3(ctx);
 #endif
 }

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -35,6 +35,10 @@
 //#define NANOVG_GL3_IMPLEMENTATION
 #include <nanovg_gl.h>
 
+#if defined(NANOVG_GL2_IMPLEMENTATION) || defined(NANOVG_GLES2_IMPLEMENTATION)
+#define NANOVG_CURSOR_DISABLED
+#endif
+
 NAMESPACE_BEGIN(nanogui)
 
 std::map<GLFWwindow *, Screen *> __nanogui_screens;
@@ -141,9 +145,14 @@ static float get_pixel_ratio(GLFWwindow *window) {
 
 Screen::Screen()
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
-      mCursor(Cursor::Arrow), mBackground(0.3f, 0.3f, 0.32f, 1.f),
+#ifndef NANOVG_CURSOR_DISABLED
+      mCursor(Cursor::Arrow),
+#endif
+      mBackground(0.3f, 0.3f, 0.32f, 1.f),
       mShutdownGLFWOnDestruct(false), mFullscreen(false) {
+#ifndef NANOVG_CURSOR_DISABLED
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
+#endif
 }
 
 Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
@@ -151,9 +160,14 @@ Screen::Screen(const Vector2i &size, const std::string &caption, bool resizable,
                int stencilBits, int nSamples,
                unsigned int glMajor, unsigned int glMinor)
     : Widget(nullptr), mGLFWWindow(nullptr), mNVGContext(nullptr),
-      mCursor(Cursor::Arrow), mBackground(0.3f, 0.3f, 0.32f, 1.f), mCaption(caption),
+#ifndef NANOVG_CURSOR_DISABLED
+      mCursor(Cursor::Arrow),
+#endif
+      mBackground(0.3f, 0.3f, 0.32f, 1.f), mCaption(caption),
       mShutdownGLFWOnDestruct(false), mFullscreen(fullscreen) {
+#ifndef NANOVG_CURSOR_DISABLED
     memset(mCursors, 0, sizeof(GLFWcursor *) * (int) Cursor::CursorCount);
+#endif
 
     /* Request a forward compatible OpenGL glMajor.glMinor core profile context.
        Default value is an OpenGL 3.3 core profile context. */
@@ -375,8 +389,10 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
     mProcessEvents = true;
     __nanogui_screens[mGLFWWindow] = this;
 
+#ifndef NANOVG_CURSOR_DISABLED
     for (int i=0; i < (int) Cursor::CursorCount; ++i)
         mCursors[i] = glfwCreateStandardCursor(GLFW_ARROW_CURSOR + i);
+#endif
 
     /// Fixes retina display-related font rendering issue (#185)
     nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
@@ -385,10 +401,12 @@ void Screen::initialize(GLFWwindow *window, bool shutdownGLFWOnDestruct) {
 
 Screen::~Screen() {
     __nanogui_screens.erase(mGLFWWindow);
+#ifndef NANOVG_CURSOR_DISABLED
     for (int i=0; i < (int) Cursor::CursorCount; ++i) {
         if (mCursors[i])
             glfwDestroyCursor(mCursors[i]);
     }
+#endif
     if (mNVGContext)
         nvgDeleteContext(mNVGContext);
     if (mGLFWWindow && mShutdownGLFWOnDestruct)
@@ -548,11 +566,13 @@ bool Screen::cursorPosCallbackEvent(double x, double y) {
         p -= Vector2i(1, 2);
 
         if (!mDragActive) {
+#ifndef NANOVG_CURSOR_DISABLED
             Widget *widget = findWidget(p);
             if (widget != nullptr && widget->cursor() != mCursor) {
                 mCursor = widget->cursor();
                 glfwSetCursor(mGLFWWindow, mCursors[(int) mCursor]);
             }
+#endif
         } else {
             ret = mDragWidget->mouseDragEvent(
                 p - mDragWidget->parent()->absolutePosition(), p - mMousePos,
@@ -596,10 +616,12 @@ bool Screen::mouseButtonCallbackEvent(int button, int action, int modifiers) {
                 mMousePos - mDragWidget->parent()->absolutePosition(), button,
                 false, mModifiers);
 
+#ifndef NANOVG_CURSOR_DISABLED
         if (dropWidget != nullptr && dropWidget->cursor() != mCursor) {
             mCursor = dropWidget->cursor();
             glfwSetCursor(mGLFWWindow, mCursors[(int) mCursor]);
         }
+#endif
 
         if (action == GLFW_PRESS && (button == GLFW_MOUSE_BUTTON_1 || button == GLFW_MOUSE_BUTTON_2)) {
             mDragWidget = findWidget(mMousePos);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -470,7 +470,11 @@ void Screen::drawWidgets() {
 #endif
 
     glViewport(0, 0, mFBSize[0], mFBSize[1]);
+#ifndef NANOVG_GL2_IMPLEMENTATION
+#ifndef NANOVG_GLES2_IMPLEMENTATION
     glBindSampler(0, 0);
+#endif
+#endif
     nvgBeginFrame(mNVGContext, mSize[0], mSize[1], mPixelRatio);
 
     draw(mNVGContext);

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -50,6 +50,8 @@ inline NVGcontext* nvgCreateContext(int flags) {
   return nvgCreateGLES2(flags);
 #elif defined(NANOVG_GLES3_IMPLEMENTATION)
   return nvgCreateGLES3(flags);
+#else
+#error No NANOVG_GL*_IMPLEMENTATION macro defined
 #endif
 }
 inline void nvgDeleteContext(NVGcontext* ctx) {
@@ -61,6 +63,8 @@ inline void nvgDeleteContext(NVGcontext* ctx) {
   nvgDeleteGLES2(ctx);
 #elif defined(NANOVG_GLES3_IMPLEMENTATION)
   nvgDeleteGLES3(ctx);
+#else
+#error No NANOVG_GL*_IMPLEMENTATION macro defined
 #endif
 }
 


### PR DESCRIPTION
I am upstreaming some of the changes my team has made to nanovg and nanogui.

We found that nanogui was making assumptions about the available versions of OpenGL, particularly in Emscripten builds where browsers only support odd versions.

We fixed this by ifdef-guarding the use of cursors, and providing a convenience function to call the correct create-/delete-context functions.