### PR TITLE
Add example_icons to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ rules.ninja
 Makefile
 bin2c
 example[1-9]
+example_icons
 icons
 *~
 nanogui*.so


### PR DESCRIPTION
I am upstreaming some of the changes my team has made to nanovg and nanogui.

We found that when building the nanogui project, the file `./example_icons` was generated, but not git-ignored.