### PR TITLE
Remove dangling children from Screen

### DIFF
--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -179,7 +179,7 @@ public:
 
     /* Internal helper functions */
     void updateFocus(Widget *widget);
-    void disposeWindow(Window *window);
+    void disposeWidget(Widget *widget);
     void centerWindow(Window *window);
     void moveWindowToFront(Window *window);
     void drawWidgets();

--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -274,6 +274,13 @@ protected:
      */
     inline float icon_scale() const { return mTheme->mIconScale * mIconExtraScale; }
 
+private:
+    /**
+     * Convenience function to share logic between both signatures of
+     * ``removeChild``.
+     */
+    void removeChildHelper(const std::vector<Widget *>::iterator& child_it);
+
 protected:
     Widget *mParent;
     ref<Theme> mTheme;

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -2598,7 +2598,7 @@ static const char *__doc_nanogui_Screen_charCallbackEvent = R"doc()doc";
 
 static const char *__doc_nanogui_Screen_cursorPosCallbackEvent = R"doc()doc";
 
-static const char *__doc_nanogui_Screen_disposeWindow = R"doc()doc";
+static const char *__doc_nanogui_Screen_disposeWidget = R"doc(Remove Screen's references to a widget and its children)doc";
 
 static const char *__doc_nanogui_Screen_drawAll = R"doc(Draw the Screen contents)doc";
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -686,12 +686,17 @@ void Screen::updateFocus(Widget *widget) {
         moveWindowToFront((Window *) window);
 }
 
-void Screen::disposeWindow(Window *window) {
-    if (std::find(mFocusPath.begin(), mFocusPath.end(), window) != mFocusPath.end())
+void Screen::disposeWidget(Widget *widget) {
+    if (std::find(mFocusPath.begin(), mFocusPath.end(), widget) != mFocusPath.end())
         mFocusPath.clear();
-    if (mDragWidget == window)
+
+    if (mDragWidget == widget) {
         mDragWidget = nullptr;
-    removeChild(window);
+        mDragActive = false;
+    }
+
+    for (auto child : widget->children())
+        disposeWidget(child);
 }
 
 void Screen::centerWindow(Window *window) {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -152,13 +152,23 @@ void Widget::addChild(Widget * widget) {
 }
 
 void Widget::removeChild(const Widget *widget) {
-    mChildren.erase(std::remove(mChildren.begin(), mChildren.end(), widget), mChildren.end());
-    widget->decRef();
+    removeChildHelper(std::find(mChildren.begin(), mChildren.end(), widget));
 }
 
 void Widget::removeChild(int index) {
-    Widget *widget = mChildren[index];
-    mChildren.erase(mChildren.begin() + index);
+    assert(index >= 0);
+    assert(index < childCount());
+    removeChildHelper(mChildren.begin() + index);
+}
+
+void Widget::removeChildHelper(const std::vector<Widget *>::iterator& child_it) {
+    if (child_it == mChildren.end())
+        return;
+    Widget *widget = *child_it;
+
+    screen()->disposeWidget(widget);
+    mChildren.erase(child_it);
+
     widget->decRef();
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -145,7 +145,7 @@ void Window::dispose() {
     Widget *widget = this;
     while (widget->parent())
         widget = widget->parent();
-    ((Screen *) widget)->disposeWindow(this);
+    ((Screen *) widget)->removeChild(this);
 }
 
 void Window::center() {


### PR DESCRIPTION
- Fixes #331.
- Closes #198.
- Closes #262 

I am upstreaming some of the changes my team has made to nanovg and nanogui.

Note: I think this is a more thorough implementation of https://github.com/wjakob/nanogui/pull/332

We found that removing widgets during an event callback sometimes raised segfaults either later on during event processing or on the subsequent draw frame. A little bit of digging showed that `Screen` was holding onto references to widgets that may have been de-allocated.

Our solution was to invoke a slightly altered form of `Screen::disposeWindow` from `removeChild` to ensure `mDragActive`, `mDragWidget`, and `mFocusPath` do not contain references to deallocated pointers.

A quick summary of changes:
* Assert that index in `Widget::removeChild(int)` is within range of `[0, Widget::childCount - 1]`
* Make `Widget::removeChildHelper`: a common helper function for `Widget::removeChild` that operates on iterators.
* Rename `Screen::disposeWindow` to `Screen::disposeWidget`, change the argument type to `Widget*`, and recurse to dispose of children as well.
* Update the only reference to `Screen::disposeWindow` to call `Screen::removeChild` (which will eventually call `Screen::disposeWidget` now).

This may break a few users because:
* We've added an assert that will fail at runtime for bad input that would previously go unchecked.
* We've renamed a public function that some users may have been calling. Fortunately, they'll see this one at compile-time.

**TODO**

- [ ] rebase to current master
- [ ] move changes in `py_doc.h` to be a docstring comment in `screen.h`: `/// Remove any internal references to a widget and its children.`
    - [ ] run `make mkdoc` target to regenerate `py_doc.h`
- [ ] decision needed about `removeChildHelper` vs `removeChild(Widget *)` https://github.com/wjakob/nanogui/pull/341#issuecomment-480737702
    - [ ] implement the decision if changes needed
- [ ] `disposeWidget(Widget *)` => `disposeWidget(const Widget *)`