### PR TITLE
Fixed bug which causes ImagePanel to highlight images when it shouldn't

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "ext/nanovg"]
     path = ext/nanovg
     url = https://github.com/wjakob/nanovg
-[submodule "ext/glfw"]
-    path = ext/glfw
-    url = https://github.com/wjakob/glfw
 [submodule "ext/glew"]
     path = ext/glew
     url = https://github.com/nigels-com/glew
@@ -13,3 +10,6 @@
 [submodule "ext/pybind"]
     path = ext/pybind11
     url = https://github.com/pybind/pybind11
+[submodule "ext/glfw"]
+	path = ext/glfw
+	url = https://github.com/mhbackes/glfw

--- a/src/imagepanel.cpp
+++ b/src/imagepanel.cpp
@@ -33,6 +33,7 @@ int ImagePanel::indexForPosition(const Vector2i &p) const {
     float iconRegion = mThumbSize / (float)(mThumbSize + mSpacing);
     bool overImage = pp.x() - std::floor(pp.x()) < iconRegion &&
                     pp.y() - std::floor(pp.y()) < iconRegion;
+    overImage &= pp.x() >= 0 && pp.y() >= 0;
     Vector2i gridPos = pp.cast<int>(), grid = gridSize();
     overImage &= ((gridPos.array() >= 0).all() &&
                  (gridPos.array() < grid.array()).all());


### PR DESCRIPTION
I found a visual bug which causes ImagePanel to highlight an image when the mouse cursor is slightly above or to the left of the panel.

The bug is can be seen in example1 as shown in the following gif:

![glitch_hd](https://user-images.githubusercontent.com/5702847/53044292-56900400-3469-11e9-903c-0f1fc38d63a9.gif)

The fix adds an additional test which checks if the position of the cursor is positive.