### PR TITLE
update to official Eigen 3.3.7, shallow submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,8 @@
     url = https://github.com/wjakob/glfw
 [submodule "ext/eigen"]
     path = ext/eigen
-    url = https://github.com/libigl/eigen.git
+    url = https://github.com/eigenteam/eigen-git-mirror.git
+    shallow = true
 [submodule "ext/pybind"]
     path = ext/pybind11
     url = https://github.com/pybind/pybind11


### PR DESCRIPTION
What are your thoughts on shallow submodules?  The eigen update will reduce many warnings (at least in newer GCC), but the git history on the official mirror is massive.  With a shallow module it clones faster than pybind11 does.

- shallow submodules introduced in 2.10, september 2016
- iirc your benchmark for "oldest support" is debian stretch, [which has 2.11](https://packages.debian.org/search?keywords=git)

Did it on the fork to test: `git clone --recursive https://github.com/svenevs/nanogui.git -b deps/update-eigen`