### PR TITLE
GCC 7+ warn about switch fallthroughs

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -142,12 +142,14 @@ std::array<char, 8> utf8(int c) {
     else if (c < 0x4000000) n = 5;
     else if (c <= 0x7fffffff) n = 6;
     seq[n] = '\0';
+    // NOTE: this switch is designed to fall through.  More information:
+    // https://developers.redhat.com/blog/2017/03/10/wimplicit-fallthrough-in-gcc-7/
     switch (n) {
-        case 6: seq[5] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x4000000;
-        case 5: seq[4] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x200000;
-        case 4: seq[3] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x10000;
-        case 3: seq[2] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x800;
-        case 2: seq[1] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0xc0;
+        case 6: seq[5] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x4000000;// Falls through.
+        case 5: seq[4] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x200000; // Falls through.
+        case 4: seq[3] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x10000;  // Falls through.
+        case 3: seq[2] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x800;    // Falls through.
+        case 2: seq[1] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0xc0;     // Falls through.
         case 1: seq[0] = c;
     }
     return seq;


### PR DESCRIPTION
Prior to these comments:

```
../src/common.cpp: In function ‘std::array<char, 8> nanogui::utf8(int)’:                                                                                      
../src/common.cpp:146:59: warning: this statement may fall through [-Wimplicit-fallthrough=]                                                                  
         case 6: seq[5] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x4000000;                                                                                      
                                                         ~~^~~~~~~~~~~~                                                                                       
../src/common.cpp:147:9: note: here                                                                                                                           
         case 5: seq[4] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x200000;                                                                                       
         ^~~~                                                                                                                                                 
../src/common.cpp:147:59: warning: this statement may fall through [-Wimplicit-fallthrough=]                                                                  
         case 5: seq[4] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x200000;                                                                                       
                                                         ~~^~~~~~~~~~~                                                                                        
../src/common.cpp:148:9: note: here
         case 4: seq[3] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x10000;
         ^~~~
../src/common.cpp:148:59: warning: this statement may fall through [-Wimplicit-fallthrough=]
         case 4: seq[3] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x10000;
                                                         ~~^~~~~~~~~~
../src/common.cpp:149:9: note: here
         case 3: seq[2] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x800;
         ^~~~
../src/common.cpp:149:59: warning: this statement may fall through [-Wimplicit-fallthrough=]
         case 3: seq[2] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0x800;
                                                         ~~^~~~~~~~
../src/common.cpp:150:9: note: here
         case 2: seq[1] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0xc0;
         ^~~~
../src/common.cpp:150:59: warning: this statement may fall through [-Wimplicit-fallthrough=]
         case 2: seq[1] = 0x80 | (c & 0x3f); c = c >> 6; c |= 0xc0;
                                                         ~~^~~~~~~
../src/common.cpp:151:9: note: here
         case 1: seq[0] = c;
         ^~~~
```

I happily ignore the reality of C++ and unicode (aka I don't actually understand this code), but I'm pretty sure the fallthrough is desired here.

I'm picking this commit to rebase off of for the cmake stuff since it's fixed with simple comments (no special compilation treatment!).