### PR TITLE
Fix dangling child widgets from Screen's focus/drag

### DIFF
--- a/include/nanogui/screen.h
+++ b/include/nanogui/screen.h
@@ -179,7 +179,7 @@ public:
 
     /* Internal helper functions */
     void updateFocus(Widget *widget);
-    void disposeWindow(Window *window);
+    void disposeWidget(Widget *widget);
     void centerWindow(Window *window);
     void moveWindowToFront(Window *window);
     void drawWidgets();

--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -274,6 +274,13 @@ protected:
      */
     inline float icon_scale() const { return mTheme->mIconScale * mIconExtraScale; }
 
+private:
+    /**
+     * Convenience function to share logic between both signatures of
+     * ``removeChild``.
+     */
+    void removeChildHelper(const std::vector<Widget *>::iterator& child_it);
+
 protected:
     Widget *mParent;
     ref<Theme> mTheme;

--- a/include/nanogui/widget.h
+++ b/include/nanogui/widget.h
@@ -274,13 +274,6 @@ protected:
      */
     inline float icon_scale() const { return mTheme->mIconScale * mIconExtraScale; }
 
-private:
-    /**
-     * Convenience function to share logic between both signatures of
-     * ``removeChild``.
-     */
-    void removeChildHelper(const std::vector<Widget *>::iterator& child_it);
-
 protected:
     Widget *mParent;
     ref<Theme> mTheme;

--- a/python/py_doc.h
+++ b/python/py_doc.h
@@ -2598,7 +2598,7 @@ static const char *__doc_nanogui_Screen_charCallbackEvent = R"doc()doc";
 
 static const char *__doc_nanogui_Screen_cursorPosCallbackEvent = R"doc()doc";
 
-static const char *__doc_nanogui_Screen_disposeWindow = R"doc()doc";
+static const char *__doc_nanogui_Screen_disposeWidget = R"doc(Remove Screen's references to a widget and its children)doc";
 
 static const char *__doc_nanogui_Screen_drawAll = R"doc(Draw the Screen contents)doc";
 

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -698,9 +698,6 @@ void Screen::disposeWidget(Widget *widget) {
         mDragWidget = nullptr;
         mDragActive = false;
     }
-
-    for (auto child : widget->children())
-        disposeWidget(child);
 }
 
 void Screen::centerWindow(Window *window) {

--- a/src/screen.cpp
+++ b/src/screen.cpp
@@ -690,12 +690,17 @@ void Screen::updateFocus(Widget *widget) {
         moveWindowToFront((Window *) window);
 }
 
-void Screen::disposeWindow(Window *window) {
-    if (std::find(mFocusPath.begin(), mFocusPath.end(), window) != mFocusPath.end())
+void Screen::disposeWidget(Widget *widget) {
+    if (std::find(mFocusPath.begin(), mFocusPath.end(), widget) != mFocusPath.end())
         mFocusPath.clear();
-    if (mDragWidget == window)
+
+    if (mDragWidget == widget) {
         mDragWidget = nullptr;
-    removeChild(window);
+        mDragActive = false;
+    }
+
+    for (auto child : widget->children())
+        disposeWidget(child);
 }
 
 void Screen::centerWindow(Window *window) {

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -30,6 +30,11 @@ Widget::Widget(Widget *parent)
 }
 
 Widget::~Widget() {
+    try {
+        screen()->disposeWidget(this);
+    }
+    catch (const std::runtime_error&) {}
+
     for (auto child : mChildren) {
         if (child)
             child->decRef();
@@ -152,23 +157,13 @@ void Widget::addChild(Widget * widget) {
 }
 
 void Widget::removeChild(const Widget *widget) {
-    removeChildHelper(std::find(mChildren.begin(), mChildren.end(), widget));
+    mChildren.erase(std::remove(mChildren.begin(), mChildren.end(), widget), mChildren.end());
+    widget->decRef();
 }
 
 void Widget::removeChild(int index) {
-    assert(index >= 0);
-    assert(index < childCount());
-    removeChildHelper(mChildren.begin() + index);
-}
-
-void Widget::removeChildHelper(const std::vector<Widget *>::iterator& child_it) {
-    if (child_it == mChildren.end())
-        return;
-    Widget *widget = *child_it;
-
-    screen()->disposeWidget(widget);
-    mChildren.erase(child_it);
-
+    Widget *widget = mChildren[index];
+    mChildren.erase(mChildren.begin() + index);
     widget->decRef();
 }
 

--- a/src/widget.cpp
+++ b/src/widget.cpp
@@ -152,13 +152,23 @@ void Widget::addChild(Widget * widget) {
 }
 
 void Widget::removeChild(const Widget *widget) {
-    mChildren.erase(std::remove(mChildren.begin(), mChildren.end(), widget), mChildren.end());
-    widget->decRef();
+    removeChildHelper(std::find(mChildren.begin(), mChildren.end(), widget));
 }
 
 void Widget::removeChild(int index) {
-    Widget *widget = mChildren[index];
-    mChildren.erase(mChildren.begin() + index);
+    assert(index >= 0);
+    assert(index < childCount());
+    removeChildHelper(mChildren.begin() + index);
+}
+
+void Widget::removeChildHelper(const std::vector<Widget *>::iterator& child_it) {
+    if (child_it == mChildren.end())
+        return;
+    Widget *widget = *child_it;
+
+    screen()->disposeWidget(widget);
+    mChildren.erase(child_it);
+
     widget->decRef();
 }
 

--- a/src/window.cpp
+++ b/src/window.cpp
@@ -145,7 +145,7 @@ void Window::dispose() {
     Widget *widget = this;
     while (widget->parent())
         widget = widget->parent();
-    ((Screen *) widget)->disposeWindow(this);
+    ((Screen *) widget)->removeChild(this);
 }
 
 void Window::center() {


### PR DESCRIPTION
This is a further step along from #341 which itself addresses #332 and the other variants discussed in that PR. 

The essential change from #341 is to let a `Widget` be responsible for it's own removal from `Screen`, as a structured part of its destruction.  Reasoning follows typical RAII semantics:

Stepping back a bit, it strikes me that root of the issue is that `Screen` is holding a reference to `Widget`s for drag/focus, but isn't taking part in their reference counting.  I assume this is because `Screen` really only wants a "weak" reference, but in so far as it's still a reference (and in the absence of implementing alternatives) I suspect it's still probably a good idea that these references are accounted for somewhere..

So - this change is to let a `Widget` itself own this responsibility and make calling `Screen::disposeWidget()` part of a widget's destruction.  To destroy a widget _is_ to "dispose" of it - the two are semantically linked and so this enforces the point structurally.  It enforces the responsibility of a widget to remove itself from the screen.  

-- There is one problem with it as it stands - a `Widget` _is_ a `Screen`, so when the `Screen` is destroyed it will throw.  I've added a temporary workaround to this PR which wraps the call to `Widget::screen()` in a try/catch block: I will leave it up to you whether you might consider `Widget::screen()` returning `nullptr` to signal 'no screen' and make a `Widget` having no screen a valid part of it's semantics.  I've left this PR in draft state - happy to add further if you can't foresee any other problems with this approach.

On the plus side, it does mean we could dispense with the additional `Widget::removeChildHelper()` code and we are back to the single API `Widget::removeChild()` which thanks to @chpatton013 now covers all cases in a consistent way.

Let me know what you think.  There's a test example in [bugfix_test](https://github.com/wardw/nanogui/tree/bugfix_test) (just a variant of example1).
