### PR TITLE
[docs] breathe 4.13 is available, needs sphinx >= 2.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-# Breathe and Sphinx 2.x are incompatible at this time
-Sphinx==1.8.5
+Sphinx>=2.0
+breathe>=4.13
 exhale
 sphinx_rtd_theme


### PR DESCRIPTION
Followup to #386 which was merged after latest breathe released, which requires sphinx 2.x.

- [build succeeds again!](https://readthedocs.org/projects/nanogui/builds/9023145/)

The alternative is to pin 4.12 but 4.13 is way better, e.g. `using` is fixed for `nanogui::MatrixXf`.  I'll update the actual `conf.py` for Sphinx 2.x sometime later this summer.  We don't _need_ to change anything, but the newer `conf.py`'s are a lot cleaner.