### PR TITLE
Overload `CreateImage` to support numpy (RGBA uint8) images

### DIFF
--- a/python/nanovg.cpp
+++ b/python/nanovg.cpp
@@ -119,6 +119,16 @@ void register_nanovg(py::module &m) {
         .def("SkewY", &nvgSkewY, "angle"_a)
         .def("Scale", &nvgScale, "x"_a, "y"_a)
         .def("CreateImage", &nvgCreateImage, "filename"_a, "imageFlags"_a)
+        .def("CreateImage",
+             [](NVGcontext *ctx, const py::array_t<uint8_t>& image, int flags){
+                  if(image.ndim() != 3 || image.shape(2) != 4)
+                    throw std::invalid_argument("Unsupported image type, expected RGBA data.");
+                  return nvgCreateImageRGBA(ctx,
+                                            static_cast<int>(image.shape(1)),
+                                            static_cast<int>(image.shape(0)),
+                                            flags,
+                                            image.data());
+             }, "image"_a, "imageFlags"_a)
         .def("DeleteImage", &nvgDeleteImage, "image"_a)
         .def("LinearGradient", &nvgLinearGradient, "sx"_a, "sy"_a, "ex"_a,
              "ey"_a, "icol"_a, "ocol"_a)

--- a/python/nanovg.cpp
+++ b/python/nanovg.cpp
@@ -120,7 +120,8 @@ void register_nanovg(py::module &m) {
         .def("Scale", &nvgScale, "x"_a, "y"_a)
         .def("CreateImage", &nvgCreateImage, "filename"_a, "imageFlags"_a)
         .def("CreateImage",
-             [](NVGcontext *ctx, const py::array_t<uint8_t>& image, int flags){
+             [](NVGcontext *ctx, const py::array_t<uint8_t,py::array::c_style |
+                                                   py::array::forcecast>& image, int flags){
                   if(image.ndim() != 3 || image.shape(2) != 4)
                     throw std::invalid_argument("Unsupported image type, expected RGBA data.");
                   return nvgCreateImageRGBA(ctx,


### PR DESCRIPTION
It can be useful to open images from memory in python, for instance to show results generated with numpy.

Such functionality is implemented in this pull request by overloading the function `NVGcontext.CreateImage`

Usage example:
```python3
import PIL
import PIL.Image
import numpy as np
import nanogui

numpy_image = np.random.randint(0,255,[400,400,4]).astype(np.uint8) 
numpy_image[:,:,3] = 1 # Set alpha to 1

nanogui.init()
screen = nanogui.Screen((500, 500), "numpy image example", fullscreen=False)  
window = nanogui.Window(screen, "window") 
window.setLayout(nanogui.GroupLayout())

tex_id = screen.nvgContext().CreateImage(numpy_image, 0)
image_view = nanogui.ImageView(window, tex_id)

screen.setVisible(True)
screen.performLayout()
nanogui.mainloop()
```