### PR TITLE
Reposition a popup widget when it extends beyond the screen size

### DIFF
--- a/include/nanogui/popup.h
+++ b/include/nanogui/popup.h
@@ -67,6 +67,7 @@ protected:
 protected:
     Window *mParentWindow;
     Vector2i mAnchorPos;
+    Vector2i pPos;
     int mAnchorHeight;
     Side mSide;
 public:

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -10,6 +10,7 @@
     BSD-style license that can be found in the LICENSE.txt file.
 */
 
+#include <nanogui/screen.h>
 #include <nanogui/popup.h>
 #include <nanogui/theme.h>
 #include <nanogui/opengl.h>
@@ -37,7 +38,12 @@ void Popup::performLayout(NVGcontext *ctx) {
 void Popup::refreshRelativePlacement() {
     mParentWindow->refreshRelativePlacement();
     mVisible &= mParentWindow->visibleRecursive();
-    mPos = mParentWindow->position() + mAnchorPos - Vector2i(0, mAnchorHeight);
+    pPos = mParentWindow->position() + mAnchorPos - Vector2i(0, mAnchorHeight);
+
+    const Screen* screen = this->screen();
+    assert(screen);
+    mPos = pPos.cwiseMax(Vector2i::Zero());
+    mPos = mPos.cwiseMin(screen->size() - mSize);
 }
 
 void Popup::draw(NVGcontext* ctx) {
@@ -67,7 +73,7 @@ void Popup::draw(NVGcontext* ctx) {
     nvgBeginPath(ctx);
     nvgRoundedRect(ctx, mPos.x(), mPos.y(), mSize.x(), mSize.y(), cr);
 
-    Vector2i base = mPos + Vector2i(0, mAnchorHeight);
+    Vector2i base = pPos + Vector2i(0, mAnchorHeight);
     int sign = -1;
     if (mSide == Side::Left) {
         base.x() += mSize.x();


### PR DESCRIPTION
This one I'm not sure about, maybe I've missed an option but this patch repositions a popup widget if it 
would extend beyond the screen boundaries.

Old behavior:
![old](https://user-images.githubusercontent.com/50483426/58545630-f0531400-8203-11e9-8fea-b2a89888a00c.jpg)

New behavior:
![new](https://user-images.githubusercontent.com/50483426/58545642-f6e18b80-8203-11e9-80da-da7418285b5b.jpg)

