### PR TITLE
fix left facing popup buttons in scroll panels

### DIFF
--- a/include/nanogui/popup.h
+++ b/include/nanogui/popup.h
@@ -67,6 +67,7 @@ protected:
 protected:
     Window *mParentWindow;
     Vector2i mAnchorPos;
+    Vector2i pPos;
     int mAnchorHeight;
     Side mSide;
 public:

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -10,6 +10,7 @@
     BSD-style license that can be found in the LICENSE.txt file.
 */
 
+#include <nanogui/screen.h>
 #include <nanogui/popup.h>
 #include <nanogui/theme.h>
 #include <nanogui/opengl.h>
@@ -37,7 +38,12 @@ void Popup::performLayout(NVGcontext *ctx) {
 void Popup::refreshRelativePlacement() {
     mParentWindow->refreshRelativePlacement();
     mVisible &= mParentWindow->visibleRecursive();
-    mPos = mParentWindow->position() + mAnchorPos - Vector2i(0, mAnchorHeight);
+    pPos = mParentWindow->position() + mAnchorPos - Vector2i(0, mAnchorHeight);
+
+    const Screen* screen = this->screen();
+    assert(screen);
+    mPos = pPos.cwiseMax(Vector2i::Zero());
+    mPos = mPos.cwiseMin(screen->size() - mSize);
 }
 
 void Popup::draw(NVGcontext* ctx) {
@@ -67,7 +73,7 @@ void Popup::draw(NVGcontext* ctx) {
     nvgBeginPath(ctx);
     nvgRoundedRect(ctx, mPos.x(), mPos.y(), mSize.x(), mSize.y(), cr);
 
-    Vector2i base = mPos + Vector2i(0, mAnchorHeight);
+    Vector2i base = pPos + Vector2i(0, mAnchorHeight);
     int sign = -1;
     if (mSide == Side::Left) {
         base.x() += mSize.x();

--- a/src/popup.cpp
+++ b/src/popup.cpp
@@ -31,7 +31,7 @@ void Popup::performLayout(NVGcontext *ctx) {
         mChildren[0]->performLayout(ctx);
     }
     if (mSide == Side::Left)
-        mAnchorPos[0] -= size()[0];
+        mAnchorPos[0] = -15 - size()[0];
 }
 
 void Popup::refreshRelativePlacement() {

--- a/src/popupbutton.cpp
+++ b/src/popupbutton.cpp
@@ -77,7 +77,7 @@ void PopupButton::performLayout(NVGcontext *ctx) {
     if (mPopup->side() == Popup::Right)
         mPopup->setAnchorPos(Vector2i(parentWindow->width() + 15, posY));
     else
-        mPopup->setAnchorPos(Vector2i(0 - 15, posY));
+        mPopup->setAnchorPos(Vector2i(0 - 15 - mPopup->size()[0], posY));
 }
 
 void PopupButton::setSide(Popup::Side side) {


### PR DESCRIPTION
If a left facing popup button is in a scroll panel, the popup will be too far to the right (and in some cases cover up the button entirely) if that panel has been scrolled at all. This is (I think) because the scroll panel calls `Popup::performLayout` but not  `PopupButton::performLayout`. In the PR, both functions set the anchor to the same (x) position, so that is no longer an issue.

Example (based on example_icons.cpp):

```
#include <nanogui/nanogui.h>

using namespace nanogui;

int main(int /* argc */, char ** /* argv */) {
    nanogui::init();

    {
        // create a fixed size screen with one window
        Screen *screen = new Screen({500, 400}, "Scroll Popup", false);
        Window *window = new Window(screen, "Scroll Popup");
        window->setPosition(Vector2i(200, 15));
        window->setLayout(new BoxLayout(Orientation::Horizontal,
Alignment::Middle, 0, 6));

        // attach a vertical scroll panel
        auto vscroll = new VScrollPanel(window);
        vscroll->setFixedSize({200, 100});

        // vscroll should only have *ONE* child. this is what `wrapper` is for
        auto wrapper = new Widget(vscroll);
        wrapper->setFixedSize({200, 100});
	    wrapper->setLayout(new GroupLayout());

        new Label(wrapper, "Padding", "sans-bold");

        // right side popups are in the right place
        PopupButton *popupBtn = new PopupButton(wrapper, "good popup");
        Popup *popup = popupBtn->popup();
        popup->setLayout(new GroupLayout());
        popupBtn->setSide(Popup::Side::Right);
        new Label(popup, "this works");

        // left side popups are also anchored to the right?
        popupBtn = new PopupButton(wrapper, "bad popup");
        popup = popupBtn->popup();
        popup->setLayout(new GroupLayout());
        popupBtn->setSide(Popup::Side::Left);
        new Label(popup, "this, I assume, doesnt work");

        screen->performLayout();
        screen->setVisible(true);

        nanogui::mainloop();
    }

    nanogui::shutdown();
    return 0;
}
```
