### PR TITLE
Run performLayout() again when the combobox gets a new set of items

### DIFF
--- a/src/combobox.cpp
+++ b/src/combobox.cpp
@@ -9,6 +9,7 @@
     BSD-style license that can be found in the LICENSE.txt file.
 */
 
+#include <nanogui/screen.h>
 #include <nanogui/combobox.h>
 #include <nanogui/layout.h>
 #include <nanogui/serializer/core.h>
@@ -63,6 +64,9 @@ void ComboBox::setItems(const std::vector<std::string> &items, const std::vector
         index++;
     }
     setSelectedIndex(mSelectedIndex);
+
+    assert(screen());
+    screen()->performLayout();
 }
 
 bool ComboBox::scrollEvent(const Vector2i &p, const Vector2f &rel) {


### PR DESCRIPTION
If the item-list of a combobox changes (multiple times) at run-time it is required to re-calculate the layout again otherwise the popup widget will be stale or empty. Unfortunately there is no way to request performLayout for a single widget so they will all be recalculated.