### PR TITLE
Use dirent.h instead of deprecated sys/dir.h

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -24,7 +24,7 @@
 #if !defined(_WIN32)
 #  include <locale.h>
 #  include <signal.h>
-#  include <sys/dir.h>
+#  include <dirent.h>
 #endif
 
 NAMESPACE_BEGIN(nanogui)


### PR DESCRIPTION
`sys/dir.h` has been officially deprecated in POSIX since 1997.

It is [not present on Android](https://gitlab.com/procps-ng/procps/commit/00279d692a9a3f32cd33a39190787435a8e21ad0), and soon won't be present on FreeBSD: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=21519