### PR TITLE
Build in stb_image functions as static

### DIFF
--- a/src/example1.cpp
+++ b/src/example1.cpp
@@ -50,6 +50,7 @@
 #  pragma warning(disable: 4457 4456 4005 4312)
 #endif
 
+#define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 

--- a/src/example4.cpp
+++ b/src/example4.cpp
@@ -50,10 +50,6 @@
 #  pragma warning(disable: 4457 4456 4005 4312)
 #endif
 
-#define STB_IMAGE_STATIC
-#define STB_IMAGE_IMPLEMENTATION
-#include <stb_image.h>
-
 #if defined(_WIN32)
 #  pragma warning(pop)
 #endif

--- a/src/example4.cpp
+++ b/src/example4.cpp
@@ -50,6 +50,7 @@
 #  pragma warning(disable: 4457 4456 4005 4312)
 #endif
 
+#define STB_IMAGE_STATIC
 #define STB_IMAGE_IMPLEMENTATION
 #include <stb_image.h>
 


### PR DESCRIPTION
to prevent a multiple-defined errors when static linking with nanovg