### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -67,6 +67,20 @@ jointly built using a CMake-based build system.
 
 .. end_long_description
 
+Building NanoGUI - Using vcpkg
+----------------------------------------------------------------------------------------
+
+You can download and install NanoGUI using the `vcpkg <https://github.com/Microsoft/vcpkg>`_ dependency manager::
+
+    $ git clone https://github.com/Microsoft/vcpkg.git
+    $ cd vcpkg
+    $ ./bootstrap-vcpkg.sh
+    $ ./vcpkg integrate install
+    $ ./vcpkg install nanogui
+
+The NanoGUI port in vcpkg is kept up to date by Microsoft team members and community contributors.
+If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`_ on the vcpkg repository.
+
 Creating widgets
 ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
NanoGUI is available as a port in vcpkg, a C++ library manager that simplifies installation for NanoGUI and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build NanoGUI, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.