### PR TITLE
Fix incorrect assert() in TabWidget::removeTab(int)

### DIFF
--- a/src/tabwidget.cpp
+++ b/src/tabwidget.cpp
@@ -135,7 +135,7 @@ bool TabWidget::removeTab(const std::string &tabName) {
 }
 
 void TabWidget::removeTab(int index) {
-    assert(mContent->childCount() < index);
+    assert(index < mContent->childCount());
     mHeader->removeTab(index);
     mContent->removeChild(index);
     if (activeTab() == index)


### PR DESCRIPTION
Arguments were in a wrong order in comparison: index greater than number of children when it should be the other way.