### PR TITLE
CMake: Call target_include_directories for nanogui library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -372,6 +372,8 @@ else()
   )
 endif()
 
+target_include_directories(nanogui PUBLIC ${NANOGUI_EIGEN_INCLUDE_DIR} ext/glfw/include ext/nanovg/src include ${CMAKE_CURRENT_BINARY_DIR})
+
 if (NANOGUI_BUILD_SHARED)
   set_property(TARGET nanogui-obj PROPERTY POSITION_INDEPENDENT_CODE ON)
 endif()


### PR DESCRIPTION
This adds a call to [`target_include_directories`](https://cmake.org/cmake/help/latest/command/target_include_directories.html) for the `nanogui` target. This way, the library can be easily linked against via `target_link_libraries` without needing to worry about includes or other dependencies in the top-level project. An example can be seen [here](https://github.com/allemangD/nanogui-sample).

Specifically, [this part of the CMakeLists.txt](https://github.com/allemangD/nanogui-sample/blob/master/CMakeLists.txt#L8-L9) is all that's required to build the project. 

I anticipate there may be some reason that this approach is *not* preferred; however I have a feeling it's possible to make the CMake configuraiton simpler than what's described [here](https://nanogui.readthedocs.io/en/latest/compilation.html).