### PR TITLE
mOverflowing flag reset in TabHeader class

### DIFF
--- a/src/tabheader.cpp
+++ b/src/tabheader.cpp
@@ -297,6 +297,8 @@ void TabHeader::performLayout(NVGcontext* ctx) {
     calculateVisibleEnd();
     if (mVisibleStart != 0 || mVisibleEnd != tabCount())
         mOverflowing = true;
+    else
+        mOverflowing = false;
 }
 
 Vector2i TabHeader::preferredSize(NVGcontext* ctx) const {

--- a/src/tabheader.cpp
+++ b/src/tabheader.cpp
@@ -295,10 +295,7 @@ void TabHeader::performLayout(NVGcontext* ctx) {
         currentPosition.x() += tabPreferred.x();
     }
     calculateVisibleEnd();
-    if (mVisibleStart != 0 || mVisibleEnd != tabCount())
-        mOverflowing = true;
-    else
-        mOverflowing = false;
+    mOverflowing = mVisibleStart != 0 || mVisibleEnd != tabCount();
 }
 
 Vector2i TabHeader::preferredSize(NVGcontext* ctx) const {


### PR DESCRIPTION
File modified: src/tabheader.cpp  
Lines modified: 298  
Reason:  
The arrows (or control buttons) in TabHeader are being drawn whenever the mOverflowing flag is set.
The issue is that the mOverflowing flag is being set under certain conditions, but it is never reset.
I fixed the issue by resetting it whenever the conditions are not met, which stops drawing arrows
(or control buttons) whenever they are not needed.